### PR TITLE
cp:/i18n moddle descriptors (lossless roundtrip) + Phase 4 (acceptance orchestrator, review skills, soundness ADR)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,9 +82,12 @@ Reusable workflows live once under `skills/<name>/SKILL.md` (the single source).
 Claude Code discovers them via `.claude/skills` → `../skills`; Codex/Copilot via
 `.agents/skills` → `../skills`. Never copy a skill body into a pointer file.
 
-| Skill (open this) | Fires when you edit | Gate |
+| Skill (open this) | Fires when you… | Gate / output |
 |---|---|---|
-| `skills/bpmn-conformance/SKILL.md` | any `**/*.bpmn` | `npm run check:conformance` |
+| `skills/bpmn-conformance/SKILL.md` | edit any `**/*.bpmn` | `npm run check:conformance` |
+| `skills/bpmn-acceptance/SKILL.md` | prepare a formal Abnahme | `npm run abnahme:protokoll` (evidence only; never stamps acceptance) |
+| `skills/clinical-pathway-review/SKILL.md` | review SEM/PRA criteria | advisory findings (read-only) |
+| `skills/model-inventory/SKILL.md` | map the model set | Model Inventory Matrix (read-only) |
 
 ## Hard rules (do not violate)
 

--- a/docs/decisions/0003-soundness-tooling.md
+++ b/docs/decisions/0003-soundness-tooling.md
@@ -1,0 +1,68 @@
+# 0003 — Behavioural soundness tooling (STR-1…STR-4)
+
+- Status: accepted (approach); **implementation deferred to a piloted follow-up**
+- Date: 2026-06-25
+- Deciders: Forschungsgruppe Digital Health (FGDH), TU Dresden
+- Relates: [`0001-repo-tooling-and-conformance-gate.md`](0001-repo-tooling-and-conformance-gate.md),
+  the Abnahme instrument (`../governance/`).
+
+## Context
+
+Abnahme criteria **STR-1…STR-4** are the Muss soundness properties: option-to-complete
+(STR-1), proper completion / no leftover tokens (STR-2), no dead/unreachable activities
+(STR-3), no deadlock/livelock (STR-4). bpmnlint does **not** decide these (its
+`no-disconnected` is only partial STR-3 hygiene); they require a model checker. Until
+one is integrated and validated, the `bpmn-acceptance` Protokoll pre-filler keeps
+STR-1…STR-4 as `HUMAN-INPUT-NEEDED`.
+
+## Decision — tool choice
+
+Use **[`timKraeuter/rust_bpmn_analyzer`](https://github.com/timKraeuter/rust_bpmn_analyzer)**
+— a BPMN-specific model checker (MIT, actively maintained; last push 2026-06-02) that
+checks safeness, option-to-complete, proper-completion, no-dead-activities and
+deadlock/livelock via state-space exploration, with partial-order reduction (`--por`)
+for parallel models. It maps 1:1 onto STR-1…STR-4. (Its `bpmn-analyzer-js` sibling is the
+browser UI; we want the Rust **CLI** core.)
+
+## Why implementation is DEFERRED (not shipped in the gate yet)
+
+Three load-bearing facts make a *piloted* integration mandatory before we trust it:
+
+1. **No release / no published image** (0 GitHub releases, no crate, no ghcr image).
+   It must be **built from source** and pinned. → ship it as a **Docker image pinned by
+   `sha256` digest** (not a tag, not `master`), so a CC-BY-DOI'd artifact's checks stay
+   reproducible.
+2. **Exit-code trap.** The CLI is reported to `process::exit(1)` only on a *parse/read*
+   error; on an actual soundness **violation** it prints results and **exits 0**. A
+   naïve CI step would therefore **always pass**. → the wrapper (`tools/check-soundness.mjs`)
+   MUST parse the result payload (`property_results[].fulfilled`, or equivalent) and set
+   the exit code itself.
+3. **Element-support risk.** These models use BPMN4CP `cp:` extensions, message flows,
+   boundary events, multiple pools, and (in the overarching pathway) multiple start
+   events. The analyzer parses a pragmatic BPMN subset. → a **one-time pilot** must run
+   it over all seven files to confirm nothing trips `unsupported_elements`, and
+   **benchmark the 130 KB overarching pathway** (state space can blow up; `--por`
+   mitigates).
+
+## Pilot protocol (run once, on a Docker-capable host)
+
+1. Build a multi-stage image from the pinned source commit; record the `sha256` digest.
+2. Run the CLI over each of the 7 `.bpmn`; capture the per-property results and timing.
+3. Confirm: (a) no `unsupported_elements` for the cp:/message-flow/boundary-event/multi-pool
+   constructs; (b) the overarching pathway completes in acceptable time with `--por`.
+4. If any file is unmodelable, define the **TOOL-INCONCLUSIVE → human-review** degraded
+   mode (the wrapper exits with a distinct "inconclusive" status that neither falsely
+   passes nor hard-blocks).
+
+## Consequences / scope boundaries
+
+- After a green pilot: add `tools/check-soundness.mjs` (Docker-digest-pinned + result
+  parsing + inconclusive fallback) and a `bpmn-soundness` CI job; flip STR-1…STR-4 in the
+  Protokoll pre-filler from `HUMAN-INPUT-NEEDED` to tool-decided.
+- **Inter-process soundness is NOT covered** by checking the 7 files independently: the
+  overarching pathway calls sub-pathways via Call Activities; composition correctness
+  stays a human-review item (CONVENTIONS §8.2 clinical validation).
+- **pm4py** (`check_soundness`/WOFLAN) is a *cross-check only* and is **AGPL-3.0** — usable
+  as a separate, non-bundled CI process, never vendored/redistributed with the CC-BY model.
+- Docker is available on the maintainers' host, so the pilot is ready to run as the next
+  focused step; this ADR is the spec for it.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "check:metrics": "node tools/check-model-metrics.mjs",
     "check:roundtrip": "node tools/moddle-roundtrip.mjs",
     "check:xsd": "bash tools/validate-xsd.sh",
-    "check:conformance": "node tools/check-conformance.mjs"
+    "check:conformance": "node tools/check-conformance.mjs",
+    "abnahme:protokoll": "node tools/abnahme-protokoll.mjs"
   },
   "devDependencies": {
     "bpmn-moddle": "^10.0.0",

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,9 +6,12 @@ each `skills/<name>/SKILL.md` carries YAML frontmatter (`name`, `description`) p
 Markdown instructions. Tools match on the `description` to decide when a skill
 applies. All tool-specific files only point here — never copy a skill's body.
 
-| Skill | When it fires | Gate |
+| Skill | When it fires | Gate / output |
 |---|---|---|
-| [`bpmn-conformance`](bpmn-conformance/SKILL.md) | editing any `**/*.bpmn` | `npm run check:conformance` |
+| [`bpmn-conformance`](bpmn-conformance/SKILL.md) | editing any `**/*.bpmn` | `npm run check:conformance` (deterministic) |
+| [`bpmn-acceptance`](bpmn-acceptance/SKILL.md) | preparing a formal Abnahme | `npm run abnahme:protokoll` → pre-filled Protokoll (never stamps acceptance) |
+| [`clinical-pathway-review`](clinical-pathway-review/SKILL.md) | reviewing a pathway for the SEM/PRA criteria | advisory findings only (LLM-judgment, read-only) |
+| [`model-inventory`](model-inventory/SKILL.md) | mapping what the model set contains | a Model Inventory Matrix (read-only) |
 
 ## How each tool consumes these skills
 
@@ -24,11 +27,10 @@ applies. All tool-specific files only point here — never copy a skill's body.
 
 These are designed but not shipped; they arrive with their backing tools:
 
-- **bpmn-acceptance** — runs the automatable Abnahme A-checks and emits a pre-filled
-  `docs/governance/abnahme-protokoll-…md` (it never stamps the overall decision).
-- **clinical-pathway-review** — advisory LLM review for the SEM/PRA criteria (never
-  pass/fail; evidence for human reviewers).
-- **bpmn-soundness** — STR-1..4 behavioural soundness via an external checker.
+- **bpmn-soundness** — STR-1…4 behavioural soundness via an external model checker
+  (`rust_bpmn_analyzer`). Approach + pilot protocol in
+  [`docs/decisions/0003-soundness-tooling.md`](../docs/decisions/0003-soundness-tooling.md);
+  until piloted, STR-1…4 stay `HUMAN-INPUT-NEEDED` in the `bpmn-acceptance` Protokoll.
 
 ## Editing rule
 

--- a/skills/bpmn-acceptance/SKILL.md
+++ b/skills/bpmn-acceptance/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: bpmn-acceptance
+description: Prepare a pre-filled Abnahme (acceptance) Protokoll for the lung-cancer pathway models by running the automatable A-checks and stamping every review/consensus criterion as HUMAN-INPUT-NEEDED. Use before a formal acceptance meeting to assemble the technical evidence. It NEVER stamps the overall acceptance — that is a human decision.
+---
+
+# BPMN acceptance (Protokoll pre-filler)
+
+You assemble **evidence**, you do **not** approve. The Abnahme instrument
+(`docs/governance/`) decides acceptance via three gates — Technical (tools),
+Clinical (expert consensus), Pragmatic (joint walkthrough) — and only humans sign off.
+
+## Run
+
+```bash
+npm run abnahme:protokoll              # print a pre-filled Protokoll to stdout
+npm run abnahme:protokoll > protokoll.md
+```
+
+It runs the automatable (method **A**) checks — `lint:bpmn`, `check:metrics`,
+`check:roundtrip` — and emits the `docs/governance/abnahme-protokoll-…md` shape with:
+
+- the **A-rows it can decide** ticked with the tool evidence (e.g. SYN-5 from the
+  metrics gate; supporting bpmnlint + cp:/i18n roundtrip rows),
+- **`HUMAN-INPUT-NEEDED`** on every review (R) / consensus (K) row **and** on any
+  A-criterion whose tool is not yet integrated — currently **STR-1…STR-4** (soundness),
+- the **automatable part of the Technical gate**, with the human/tool-pending part
+  called out,
+- **no** Clinical/Pragmatic gate verdict and **no** overall decision.
+
+## Rules (do not break)
+
+- Never convert a `HUMAN-INPUT-NEEDED` row into a ✓. SEM-1 completeness, SEM-6
+  (consensus), PRA-1 (walkthrough) and the overall decision are human — full stop.
+- The generated file is a **draft for the acceptance meeting**, not a record of
+  acceptance. The signed record is the human-completed
+  `docs/governance/abnahme-protokoll-bpmn-patientenpfad.md`.
+- STR-1…STR-4 stay `HUMAN-INPUT-NEEDED` until the soundness tool is integrated and
+  validated (see `docs/decisions/0003`); do not claim soundness from bpmnlint.

--- a/skills/clinical-pathway-review/SKILL.md
+++ b/skills/clinical-pathway-review/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: clinical-pathway-review
+description: Advisory, read-only review of a lung-cancer BPMN pathway against the Abnahme clinical (SEM) and pragmatic (PRA) criteria. Use to prepare evidence for the clinical/pragmatic acceptance gates. Produces findings only — it NEVER returns a pass/fail and never substitutes for the human consensus (SEM-6) or joint walkthrough (PRA-1).
+---
+
+# Clinical pathway review (advisory)
+
+You produce **evidence and questions for the human reviewers**, not verdicts. The
+clinical and pragmatic acceptance gates are decided by people (see `docs/governance/`).
+This is the only skill in the repo that is LLM-judgment rather than a deterministic
+tool, so be explicit about uncertainty and cite the element ids / labels you reason from.
+
+## Scope (advisory only)
+
+Read the `.bpmn` / `.svg` and the modelling reference (`CONVENTIONS.md`) and surface
+findings for these Abnahme criteria:
+
+| Abnahme | What to look for | Output |
+|---|---|---|
+| **SEM-2** guideline/evidence reference | activities that should cite S3-LL / nNGM but carry no annotation | a list of candidates |
+| **SEM-3** essential steps complete | missing restaging / aftercare / follow-up vs. the expected course | gaps to confirm |
+| **SEM-4** transitions tied to deadlines/criteria | gateways/edges with vague conditions; missing timer events at time-critical points | candidates |
+| **SEM-5** target population/scope delimited | whether the scope (e.g. NSCLC stage III–IV) is stated | present / absent |
+| **SEM-7** domain artifacts (BPMN4CP) | quality indicators (`cp:qualityIndicator`), resources, documents present where expected | inventory + gaps |
+| **PRA-2** stakeholder views | whether an overview and a technical view exist/could be derived | observation |
+| **PRA-3** relevance | elements that look superfluous for the acceptance purpose | candidates (gentle) |
+| **SYN-3** (final, labels) | verb-object label deviations bpmnlint cannot judge (German clinical grammar) | candidates |
+
+## Hard rules
+
+- **Never** output an acceptance decision, gate verdict, or a ✓/✗ on any criterion.
+  Phrase everything as "candidate", "to confirm with a clinician", or "gap to verify".
+- **SEM-1** (multidisciplinary completeness), **SEM-6** (expert consensus, K), and
+  **PRA-1** (joint walkthrough, R) are **human-only** — you may note observations but
+  must not claim them satisfied.
+- Do not edit models or documents. Read-only.
+- Flag any content that looks like **real patient data** (these models must contain
+  only synthetic/abstract content) as a priority finding.
+
+The deterministic A-criteria (SYN/STR) are handled by `bpmn-conformance` and the
+`bpmn-acceptance` Protokoll pre-filler — do not duplicate them here.

--- a/skills/model-inventory/SKILL.md
+++ b/skills/model-inventory/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: model-inventory
+description: Produce a Markdown inventory matrix of the BPMN pathway models (the overarching pathway + sub-pathways) — their scope, lanes/roles, gateways, Call Activities/decomposition, quality indicators (cp:), and start/end events. Use to get a first-pass map of what the model set contains for review or documentation. Read-only — reports for human review, never edits.
+---
+
+# Model inventory
+
+Build a first-pass **Feature/Model Inventory Matrix** across the seven `.bpmn` files
+so a reviewer can see the whole pathway set at a glance. Read-only.
+
+## How
+
+Prefer the existing tooling for the mechanical counts, then summarise:
+
+```bash
+npm run check:metrics      # per-file: levels, start/end events, gateways, lanes, prefix
+```
+
+For deeper structure, parse with bpmn-moddle + the cp: descriptor
+(`tools/moddle/descriptors.mjs`) — e.g. to list `cp:qualityIndicator`s, Call Activities,
+and lanes per model.
+
+## Output — a Markdown table, one row per model
+
+| Model | Scope (from labels/docs) | Levels | Start/End | Gateways (XOR/AND/**OR**) | Lanes / roles | Call Activities | Quality indicators (cp:) | Notes |
+|---|---|---|---|---|---|---|---|---|
+
+Then a short narrative: the decomposition map (overarching → which sub-pathways via Call
+Activity), and any **preliminary** observations (e.g. files carrying OR-gateways, files
+with no lanes). Mark maturity/observations as **PRELIMINARY** — this skill suggests, it
+does not decide. Cross-link to `docs/governance/` for the acceptance view and to
+`CONVENTIONS.md` for the rules.
+
+## Rules
+
+- Read-only; never edit a model or delete anything.
+- Do not assign an acceptance status — that is the Abnahme instrument's and the human
+  reviewers' job.

--- a/tools/abnahme-protokoll.mjs
+++ b/tools/abnahme-protokoll.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Abnahme protocol pre-filler (evidence preparer — NEVER an approver).
+ *
+ * Runs the automatable (method "A") conformance checks and emits a pre-filled
+ * Abnahme Protokoll (docs/governance/abnahme-protokoll-bpmn-patientenpfad.md shape):
+ *   - the A-rows it can decide are ticked with the tool evidence,
+ *   - every review (R) / consensus (K) row, and any A-criterion whose tool is not yet
+ *     available (STR-1..4 soundness), is stamped HUMAN-INPUT-NEEDED,
+ *   - it reports the automatable part of the Technical gate,
+ *   - it NEVER stamps the Clinical/Pragmatic gates or the overall decision — those are
+ *     human (see docs/governance/).
+ *
+ * Usage:  node tools/abnahme-protokoll.mjs            # print to stdout
+ *         node tools/abnahme-protokoll.mjs > protokoll.md
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+function run(args) {
+  const r = spawnSync(process.execPath, args, { encoding: 'utf8' });
+  const out = `${r.stdout || ''}${r.stderr || ''}`;
+  const summary = out.trim().split('\n').filter(Boolean).pop() || '';
+  return { pass: (r.status ?? 1) === 0, summary: summary.replace(/\s+/g, ' ').trim() };
+}
+const git = (args) => {
+  const r = spawnSync('git', args, { encoding: 'utf8' });
+  return (r.status === 0 ? r.stdout : '').trim();
+};
+
+const lint = run(['tools/lint-bpmn.mjs']);
+const metrics = run(['tools/check-model-metrics.mjs']);
+const roundtrip = run(['tools/moddle-roundtrip.mjs']);
+
+const commit = git(['rev-parse', '--short', 'HEAD']) || '(unknown)';
+const version = existsSync('version.txt') ? readFileSync('version.txt', 'utf8').trim() : '(unset)';
+const date = new Date().toISOString().slice(0, 10);
+
+const yn = (ok) => (ok ? '☑ ✓' : '☐ ✗');
+const H = 'HUMAN-INPUT-NEEDED';
+
+const md = `# Abnahmeprotokoll (vorausgefüllt — Tool-Evidenz) — BPMN-Lungenkrebspatientenpfad
+
+> Auto-generiert von \`tools/abnahme-protokoll.mjs\` am ${date}. **Dies ist KEINE Freigabe.**
+> Nur die automatisierbaren (A)-Kriterien sind tool-vorbefüllt; R/K-Kriterien, die drei
+> Gates und die Gesamtentscheidung bleiben menschlich (siehe \`docs/governance/\`).
+> Maßgebliches Protokoll-Template: \`docs/governance/abnahme-protokoll-bpmn-patientenpfad.md\`.
+
+## 0. Rahmendaten
+
+| Feld | Eintrag |
+|---|---|
+| Pfad / Modellname | mihub-lung-cancer-pathway (alle Modelle) |
+| Modellversion | ${version} |
+| Commit | ${commit} |
+| Ziel-Conformance-Klasse | Analytic (ohne OR-Gateways) — ADR-0001 |
+| Datum (Vorbefüllung) | ${date} |
+| Kriteriengrundlage | Abnahme-Instrument v0.3.1 |
+
+## 1. Prüfergebnisse
+
+**Codes:** ✓ erfüllt · ✗ nicht erfüllt · ${H} = menschliche Prüfung nötig. **Methode:** A=Tool, R=Review, K=Konsens.
+
+### A · Technisch (automatisierbar)
+
+| ID | Kriterium | M/S | Methode | Ergebnis | Beleg (Tool) |
+|---|---|---|---|---|---|
+| SYN-1 | Conformance-Klasse deklariert & eingehalten | M | A | ☑ ✓ (deklariert) | Analytic, ADR-0001; Einhaltung via SYN-5/bpmnlint |
+| SYN-2 | Genau ein Start-/ein End-Event je Ebene | M | A/R | ${H} | metrics meldet Abweichungen als Hinweis — Review nötig |
+| SYN-3 | Verb-Objekt-Labels | S | R | ${H} | nicht automatisierbar |
+| SYN-4 | ≤ 50 Symbole / dekomponiert | S | A | ${H} | metrics meldet Überschreitungen als Hinweis — Review |
+| SYN-5 | Gepaarte Verzweigungen, **kein OR** | S | A/R | ${yn(metrics.pass)} | ${metrics.summary || 'metrics'} |
+| STR-1 | Jeder Durchlauf erreicht das Ende | M | A | ${H} | Soundness-Tool noch nicht integriert (Phase-4-Folgearbeit) |
+| STR-2 | Keine offenen Parallelzweige am Ende | M | A | ${H} | dito |
+| STR-3 | Keine toten/unerreichbaren Aktivitäten | M | A | ${H} | dito (bpmnlint deckt nur Teilhygiene ab) |
+| STR-4 | Kein Deadlock/Livelock | M | A | ${H} | dito |
+| — | (Stütze) bpmnlint Strukturkorrektheit | — | A | ${yn(lint.pass)} | ${lint.summary || 'bpmnlint'} |
+| — | (Stütze) cp:/i18n Roundtrip verlustfrei | — | A | ${yn(roundtrip.pass)} | ${roundtrip.summary || 'roundtrip'} |
+
+### B · Klinisch (Inhaltsvalidität)
+
+| ID | Kriterium | M/S | Methode | Ergebnis |
+|---|---|---|---|---|
+| SEM-1 | Multidisziplinär (Disziplinen als Lane) | M | R | ${H} |
+| SEM-2 | Leitlinien-/Evidenzbezug | S* | R | ${H} |
+| SEM-3 | Wesentliche Schritte vollständig | S* | R | ${H} |
+| SEM-4 | Übergänge an Fristen/Kriterien | S* | R | ${H} |
+| SEM-5 | Zielpopulation/Standardisierung | S* | R | ${H} |
+| SEM-6 | Face Validity (Konsens) | M | K | ${H} |
+| SEM-7 | Domänen-Artefakte erfasst | S | R | ${H} |
+
+### C · Pragmatisch (gemeinsam)
+
+| ID | Kriterium | M/S | Methode | Ergebnis |
+|---|---|---|---|---|
+| PRA-1 | Beide Seiten verstehen das Modell gleich | M | R | ${H} |
+| PRA-2 | Übersichts- und Detailsicht vorhanden | S | R | ${H} |
+| PRA-3 | Keine überflüssigen Elemente | S | R | ${H} |
+
+## 2. Gate-Auswertung
+
+| Gate | Bedingung | Tool-Teil | Verbleibend |
+|---|---|---|---|
+| Technisch | SYN-1, SYN-2, STR-1…4 (alle Muss) | SYN-5 ${metrics.pass ? '✓' : '✗'}, bpmnlint ${lint.pass ? '✓' : '✗'}, roundtrip ${roundtrip.pass ? '✓' : '✗'} | **STR-1…4 + SYN-2 menschlich/Tool ausstehend** |
+| Klinisch | Kinsman-Gate **und** SEM-6 | — | **vollständig menschlich** |
+| Pragmatisch | PRA-1 | — | **menschlich** |
+
+## 3. Gesamtentscheidung
+
+**${H}** — wird ausschließlich von den menschlichen Leads im Abnahmetermin getroffen
+und unterschrieben (siehe Template §4/§5). Dieses Dokument liefert nur Tool-Evidenz.
+`;
+
+process.stdout.write(md);
+// Non-zero exit mirrors the automatable technical signal, so CI can surface it.
+process.exit(lint.pass && metrics.pass && roundtrip.pass ? 0 : 1);

--- a/tools/check-conformance.mjs
+++ b/tools/check-conformance.mjs
@@ -21,7 +21,7 @@ import { spawnSync } from 'node:child_process';
 const checks = [
   { name: 'bpmnlint (BPMN structure/correctness)', cmd: process.execPath, args: ['tools/lint-bpmn.mjs'], blocking: true },
   { name: 'model metrics (Abnahme SYN-5 blocking; SYN-2/4 advisory)', cmd: process.execPath, args: ['tools/check-model-metrics.mjs'], blocking: true },
-  { name: 'moddle roundtrip (serialization stability)', cmd: process.execPath, args: ['tools/moddle-roundtrip.mjs'], blocking: false },
+  { name: 'moddle roundtrip (cp:/i18n lossless + stable)', cmd: process.execPath, args: ['tools/moddle-roundtrip.mjs'], blocking: true },
   { name: 'XSD core (OMG BPMN20.xsd)', cmd: 'bash', args: ['tools/validate-xsd.sh'], blocking: false },
 ];
 

--- a/tools/check-model-metrics.mjs
+++ b/tools/check-model-metrics.mjs
@@ -30,6 +30,7 @@
 import { readFileSync } from 'node:fs';
 import { BpmnModdle } from 'bpmn-moddle';
 import { resolveBpmnFiles } from './bpmn-files.mjs';
+import { extensions } from './moddle/descriptors.mjs';
 
 const MAX_ELEMENTS_PER_LEVEL = 50; // Abnahme SYN-4 / 7PMG G7
 
@@ -64,7 +65,7 @@ for (const file of files) {
   const xml = readFileSync(file, 'utf8');
   prefixes.set(file, rootPrefix(xml));
 
-  const moddle = new BpmnModdle();
+  const moddle = new BpmnModdle(extensions);
   let definitions;
   try {
     ({ rootElement: definitions } = await moddle.fromXML(xml));

--- a/tools/lint-bpmn.mjs
+++ b/tools/lint-bpmn.mjs
@@ -10,13 +10,12 @@
  *
  * Why programmatic (not the bpmnlint CLI): these models carry rich clinical
  * extension content (`cp:` BPMN4CP quality indicators, 500+ `i18n:translation`
- * elements) for which no moddle descriptor is registered yet. The CLI would
- * elevate every such "unparsable extension content" import warning to an error
- * and drown the genuine structural findings. We therefore parse with bpmn-moddle
- * ourselves (absorbing those extension-import warnings) and lint the parsed tree,
- * so bpmnlint reports ONLY real structural rule violations. Formalising the
- * `cp:`/`i18n:` descriptors (so the extension content is validated too) is a
- * tracked follow-up; see tools/moddle-roundtrip.mjs and docs/decisions/0001.
+ * elements). The bpmnlint CLI would elevate every "unparsable extension content"
+ * import warning to an error and drown the genuine structural findings. We therefore
+ * parse with bpmn-moddle ourselves — with the `cp:` descriptor from
+ * tools/moddle/descriptors.mjs registered (so cp:qualityIndicator parses cleanly and
+ * its QualityIndicator ids resolve) — and lint the parsed tree, so bpmnlint reports
+ * ONLY real structural rule violations.
  *
  * The clinical/size/gateway conventions of the Abnahme instrument that bpmnlint
  * does not cover (SYN-2/4, and SYN-5 cross-checked) live in
@@ -31,6 +30,7 @@ import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { BpmnModdle } from 'bpmn-moddle';
 import { resolveBpmnFiles } from './bpmn-files.mjs';
+import { extensions } from './moddle/descriptors.mjs';
 
 const require = createRequire(import.meta.url);
 const { Linter } = require('bpmnlint');
@@ -54,11 +54,11 @@ console.log(`bpmnlint: linting ${files.length} file(s)…\n`);
 
 for (const file of files) {
   const xml = readFileSync(file, 'utf8');
-  const moddle = new BpmnModdle();
+  const moddle = new BpmnModdle(extensions);
 
   let rootElement;
   try {
-    // Ignore extension-content import warnings on purpose (see header).
+    // Benign extension warnings are ignored on purpose (see header).
     ({ rootElement } = await moddle.fromXML(xml));
   } catch (err) {
     console.log(`✖ ${file}\n    parse error: ${err.message}`);

--- a/tools/moddle-roundtrip.mjs
+++ b/tools/moddle-roundtrip.mjs
@@ -1,32 +1,34 @@
 #!/usr/bin/env node
 /**
- * Serialization-stability + extension-content roundtrip check (INFORMATIONAL).
+ * Lossless / stability roundtrip check for the clinical extension content
+ * (BLOCKING on data loss or instability).
+ *
+ * The models carry BPMN4CP `cp:` quality indicators (modelled in
+ * tools/moddle/bpmn4cp.json) and `i18n:translation` content. With the `cp:`
+ * descriptor registered, bpmn-moddle parses and re-serializes all of it losslessly
+ * (the nested i18n:translation rides along via lax extensionElements handling — see
+ * tools/moddle/descriptors.mjs for why no i18n descriptor is registered).
  *
  * For each file:
- *   1. parse (fromXML) with bpmn-moddle
+ *   1. parse (fromXML) with the cp: descriptor registered
  *   2. serialize (toXML, formatted)   -> A
  *   3. re-parse A and re-serialize     -> B
  *   4. assert A === B                   (stable / idempotent serialization)
- *   5. count custom extension elements (cp:/i18n:) in the source and surface
- *      bpmn-moddle parse warnings
- *
- * IMPORTANT — current coverage: this repo's clinical extension data lives under the
- * `cp:` (BPMN4CP, http://www.helict.de/bpmn4cp) and `i18n:` namespaces. No moddle
- * descriptor is registered for them yet, so bpmn-moddle treats that content as
- * generic/unparsed and may drop it on save. This check therefore reports extension
- * presence and parse warnings as NON-FATAL signals (motivating a follow-up that
- * registers a `cp:`/`i18n:` moddle descriptor to make the roundtrip lossless).
- * The one thing it does treat as a real bug is *instability* (A !== B).
+ *   5. assert cp:/i18n element count is preserved (no extension elements dropped)
  *
  * Severity:
- *   FAIL (exit 1) : serialization is not stable (A !== B) — a real bug.
- *   WARN (exit 0) : extension content present but not modelled, or parse warnings.
+ *   FAIL (exit 1) : parse error, OR cp:/i18n elements dropped on parse, OR
+ *                   serialization not stable (A !== B). These are real data loss / bugs.
+ *   WARN (exit 0) : benign "unknown attribute" notices (e.g. the cp:-prefixed
+ *                   cp:selectionBehavior / cp:definitionCanonical, and DI colour
+ *                   attributes) — preserved verbatim via lax $attrs, never dropped.
  *
  * Usage: node tools/moddle-roundtrip.mjs [file.bpmn ...]
  */
 import { readFileSync } from 'node:fs';
 import { BpmnModdle } from 'bpmn-moddle';
 import { resolveBpmnFiles } from './bpmn-files.mjs';
+import { extensions } from './moddle/descriptors.mjs';
 
 const files = resolveBpmnFiles(process.argv.slice(2));
 if (!files.length) {
@@ -38,13 +40,13 @@ if (!files.length) {
 const extCount = (xml) => (xml.match(/<(?:cp|i18n):[A-Za-z]/g) || []).length;
 
 let failures = 0;
-let warnTotal = 0;
+let benignWarnTotal = 0;
 
 console.log(`roundtrip: checking ${files.length} file(s)…\n`);
 
 for (const file of files) {
   const xml = readFileSync(file, 'utf8');
-  const moddle = new BpmnModdle();
+  const moddle = new BpmnModdle(extensions);
 
   let rootElement;
   let warnings = [];
@@ -63,31 +65,35 @@ for (const file of files) {
   const stable = a === b;
   const inCount = extCount(xml);
   const outCount = extCount(a);
-  const droppedExt = inCount > outCount;
-  warnTotal += warnings.length;
+  const dropped = inCount > outCount;
 
-  const lossy = warnings.length > 0 || droppedExt;
-  const status = !stable ? '✖' : lossy ? '⚠' : '✓';
+  // Only "unknown attribute" warnings are benign (lax-preserved). Any other warning
+  // (e.g. "unparsable content <element>") indicates content the model cannot represent.
+  const lossWarnings = warnings.filter((w) => !/unknown attribute/i.test(String(w.message)));
+  const benignWarnings = warnings.length - lossWarnings.length;
+  benignWarnTotal += benignWarnings;
+
+  const hardFail = !stable || dropped || lossWarnings.length > 0;
+  const status = hardFail ? '✖' : benignWarnings ? '⚠' : '✓';
   console.log(`${status} ${file}`);
-  console.log(`    stable=${stable}  cp:/i18n: extension-elements ${inCount} -> ${outCount}`);
+  console.log(`    stable=${stable}  cp:/i18n elements ${inCount} -> ${outCount}  (${benignWarnings} benign attr warning(s))`);
   if (!stable) console.log('    serialization is NOT idempotent (re-serializing changed the output)');
-  if (droppedExt) console.log('    note: extension content dropped on parse (no cp:/i18n: moddle descriptor registered yet)');
-  for (const w of warnings.slice(0, 3)) {
-    console.log(`    warning: ${String(w.message || w).split('\n')[0]}`);
+  if (dropped) console.log(`    DATA LOSS: ${inCount - outCount} extension element(s) dropped on parse`);
+  for (const w of lossWarnings.slice(0, 5)) {
+    console.log(`    loss warning: ${String(w.message).split('\n')[0]}`);
   }
-  if (warnings.length > 3) console.log(`    … and ${warnings.length - 3} more warning(s)`);
   console.log('');
 
-  if (!stable) failures++;
+  if (hardFail) failures++;
 }
 
-if (warnTotal || failures === 0) {
+if (benignWarnTotal) {
   console.log(
-    'roundtrip: extension/parse warnings are informational — register a cp:/i18n: moddle descriptor to make the roundtrip lossless (follow-up).'
+    `roundtrip: ${benignWarnTotal} benign "unknown attribute" notice(s) — preserved verbatim via lax $attrs (cp:selectionBehavior / cp:definitionCanonical / DI colours). Not data loss.`
   );
 }
 if (failures) {
-  console.error(`\nroundtrip: ${failures} file(s) had unstable serialization.`);
+  console.error(`\nroundtrip: ${failures} file(s) failed (data loss or unstable serialization).`);
   process.exit(1);
 }
-console.log('roundtrip: OK (serialization stable).');
+console.log('roundtrip: OK (lossless + stable).');

--- a/tools/moddle/bpmn4cp.json
+++ b/tools/moddle/bpmn4cp.json
@@ -1,0 +1,35 @@
+{
+  "name": "BPMN4CP",
+  "uri": "http://www.helict.de/bpmn4cp",
+  "prefix": "cp",
+  "xml": { "tagAlias": "lowerCase" },
+  "types": [
+    {
+      "name": "ProcessExtension",
+      "extends": ["bpmn:Process"],
+      "properties": [
+        { "name": "qualityIndicators", "type": "QualityIndicator", "isMany": true }
+      ]
+    },
+    {
+      "name": "QualityIndicator",
+      "properties": [
+        { "name": "id", "type": "String", "isAttr": true, "isId": true },
+        { "name": "name", "type": "String", "isAttr": true },
+        { "name": "dataObjectRef", "type": "String", "isAttr": true },
+        { "name": "extensionElements", "type": "bpmn:ExtensionElements" },
+        { "name": "qIDefinition", "type": "QIDefinition" }
+      ]
+    },
+    {
+      "name": "QIDefinition",
+      "properties": [
+        { "name": "type", "type": "String", "isAttr": true },
+        { "name": "text", "type": "String", "isAttr": true },
+        { "name": "numerator", "type": "String", "isAttr": true },
+        { "name": "denumerator", "type": "String", "isAttr": true },
+        { "name": "extensionElements", "type": "bpmn:ExtensionElements" }
+      ]
+    }
+  ]
+}

--- a/tools/moddle/descriptors.mjs
+++ b/tools/moddle/descriptors.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * Loads the custom moddle descriptor(s) for the clinical extension content used by
+ * the pathway models, so bpmn-moddle parses and re-serializes it LOSSLESSLY instead
+ * of dropping it on save.
+ *
+ *   cp:  BPMN4CP (http://www.helict.de/bpmn4cp) — quality indicators, modelled as a
+ *        `bpmn:Process` extension (cp:qualityIndicator / cp:qIDefinition).
+ *
+ * Why NOT an i18n: descriptor (deliberate): the i18n:translation elements live inside
+ * standard <bpmn:extensionElements> (including those of the cp:qualityIndicator we
+ * model). Once the *containing* element is modelled, bpmn-moddle preserves that nested
+ * content verbatim via its lax extensionElements handling — verified lossless with 0
+ * warnings. Registering an i18n descriptor is actively HARMFUL: moddle then tries to
+ * parse i18n:translation as a typed element, trips over the `xml:lang` attribute, and
+ * DROPS the content (regressing files that were previously lossless). So we model only
+ * the container and let lax do the rest.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const load = (f) => JSON.parse(readFileSync(join(here, f), 'utf8'));
+
+export const bpmn4cp = load('bpmn4cp.json');
+
+/** The extensions object to pass to `new BpmnModdle(extensions)`. */
+export const extensions = { cp: bpmn4cp };


### PR DESCRIPTION
## Summary

Two grouped follow-ups: the **`cp:`/`i18n:` moddle descriptors** and **Phase 4 (acceptance orchestrator, advisory review skills, soundness ADR)**.

> 🥞 **Stacked on #30** (base = `feat/repo-versioning-phase-3`, which is itself stacked on #29). Diff shows only this work; it auto-retargets down to `dev` as the parents merge. Review order: #29 → #30 → this.

### `cp:`/`i18n:` moddle descriptors — roundtrip now lossless + blocking
- `tools/moddle/bpmn4cp.json` models `cp:qualityIndicator` / `cp:qIDefinition` as a `bpmn:Process` extension; the nested `i18n:translation` rides along via moddle's lax `extensionElements` handling.
- **No `i18n:` descriptor** — registering one is *harmful* (moddle trips on `xml:lang` and drops content that lax preserves). Documented in `descriptors.mjs`.
- **Verified lossless across all 7 models** (overarching 273→273 cp/i18n elements, `xml:lang` 247→247; treatment 133→133, 0 warnings). The 15 residual "unknown attribute" notices (`cp:selectionBehavior`/`definitionCanonical`, DI colours) are lax-preserved verbatim — confirmed surviving, not data loss.
- **Roundtrip promoted from informational → blocking** (fails on dropped elements or unstable serialization). Structural findings unchanged (still 99 bpmnlint errors / 4 OR-gateways).

### Phase 4
- **`bpmn-acceptance` Protokoll pre-filler** (`npm run abnahme:protokoll`, + skill): runs the automatable A-checks and emits a pre-filled Abnahme Protokoll — ticks the A-rows it can decide with tool evidence, stamps every R/K row **and** the not-yet-automated **STR-1…4** as `HUMAN-INPUT-NEEDED`, reports the automatable part of the Technical gate, and **never stamps the Clinical/Pragmatic gates or the overall decision**.
- **`clinical-pathway-review`** skill — advisory, read-only LLM-judgment review for SEM-2…7 / PRA-2…3 (never pass/fail; SEM-1/SEM-6/PRA-1 stay human).
- **`model-inventory`** skill — read-only Model Inventory Matrix.
- **ADR-0003 — soundness (STR-1…4):** chooses [`timKraeuter/rust_bpmn_analyzer`](https://github.com/timKraeuter/rust_bpmn_analyzer) (MIT, active 2026-06) and **defers implementation behind a documented pilot**, with the exact protocol.

## Why soundness is documented, not shipped (honest scope)

The research made a pilot a prerequisite, and verification confirms why: the tool has **0 releases / no image** (build-from-source + `sha256` digest pin), an **exit-0-on-violation trap** (the wrapper must parse `property_results[].fulfilled` or the gate always passes), and **element-support risk** against the `cp:`/multi-pool/boundary constructs. Building + piloting + wrapping a Rust model checker is a focused sub-project; I won't ship an unverified soundness gate. Docker is available on the host, so the pilot (per ADR-0003) is ready to run as the next step. STR-1…4 remain `HUMAN-INPUT-NEEDED` until then.

## Also deferred
SVG visual-diff (the report's lowest-priority Phase 4 item; Chromium-heavy) — not included.

## Test plan
- [x] Roundtrip verified lossless + stable on all 7 files; promoted to blocking; `npm run check:conformance` unchanged (2 blocking fails: bpmnlint + metrics; roundtrip + XSD now both pass).
- [x] `npm run abnahme:protokoll` produces a valid pre-filled Protokoll (commit/version stamped, A-rows ticked from evidence, STR + R/K = HUMAN-INPUT-NEEDED) and exits 1 with the red gate.
- [x] All 4 skills present and registered in `skills/README.md` + `AGENTS.md`.
- [ ] Soundness gate — intentionally not implemented (see ADR-0003).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
