### PR TITLE
Soundness pilot (STR-1..4): advisory check-soundness wrapper + CI (rust_bpmn_analyzer)

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -1,0 +1,57 @@
+name: Soundness (advisory)
+
+# Behavioural soundness (Abnahme STR-1..4) via rust_bpmn_analyzer (pinned by digest),
+# run as a service container. ADVISORY / non-blocking: it reports SOUND / VIOLATION /
+# INCONCLUSIVE per model and never fails the build. As of the 2026-06-25 pilot, 4/7
+# models are INCONCLUSIVE (unsupported OR-gateways + intermediate catch events) and the
+# analyzable ones violate on pre-existing defects — see docs/decisions/0003. Flip to
+# `--strict` (blocking) only after the model remodel.
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - "**/*.bpmn"
+      - "tools/check-soundness.mjs"
+      - ".github/workflows/soundness.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  soundness:
+    name: soundness (advisory)
+    runs-on: ubuntu-latest
+    services:
+      analyzer:
+        # Pinned by digest (see docs/decisions/0003). The image is the webserver binary
+        # and binds 0.0.0.0:8080; mapped to localhost:8090 on the runner.
+        image: tkra/rust_bpmn_analyzer@sha256:9d939b84e82ca0ef55e9b34847d55bacd32b293fc7ef670e53d37d2ebcd3778c
+        ports:
+          - 8090:8080
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Wait for the analyzer
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS -o /dev/null http://localhost:8090/; then echo "analyzer ready"; exit 0; fi
+            sleep 1
+          done
+          echo "analyzer not ready — the wrapper will skip (advisory)."
+
+      - name: Soundness (advisory, non-blocking)
+        env:
+          SOUNDNESS_URL: http://localhost:8090/check_bpmn
+        run: node tools/check-soundness.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ Claude Code discovers them via `.claude/skills` → `../skills`; Codex/Copilot v
 | `skills/bpmn-acceptance/SKILL.md` | prepare a formal Abnahme | `npm run abnahme:protokoll` (evidence only; never stamps acceptance) |
 | `skills/clinical-pathway-review/SKILL.md` | review SEM/PRA criteria | advisory findings (read-only) |
 | `skills/model-inventory/SKILL.md` | map the model set | Model Inventory Matrix (read-only) |
+| `skills/bpmn-soundness/SKILL.md` | check STR-1…4 soundness | `npm run check:soundness` (advisory; needs the analyzer container) |
 
 ## Hard rules (do not violate)
 

--- a/docs/decisions/0003-soundness-tooling.md
+++ b/docs/decisions/0003-soundness-tooling.md
@@ -1,6 +1,7 @@
 # 0003 — Behavioural soundness tooling (STR-1…STR-4)
 
-- Status: accepted (approach); **implementation deferred to a piloted follow-up**
+- Status: accepted; **pilot executed 2026-06-25** — advisory wrapper shipped; a
+  *blocking* gate stays deferred until the model remodel (see Pilot results)
 - Date: 2026-06-25
 - Deciders: Forschungsgruppe Digital Health (FGDH), TU Dresden
 - Relates: [`0001-repo-tooling-and-conformance-gate.md`](0001-repo-tooling-and-conformance-gate.md),
@@ -54,11 +55,48 @@ Three load-bearing facts make a *piloted* integration mandatory before we trust 
    mode (the wrapper exits with a distinct "inconclusive" status that neither falsely
    passes nor hard-blocks).
 
+## Pilot results (2026-06-25 — executed)
+
+Run via the **published, pinned image**
+`tkra/rust_bpmn_analyzer@sha256:9d939b84e82ca0ef55e9b34847d55bacd32b293fc7ef670e53d37d2ebcd3778c`
+— no source build was needed (Docker Hub publishes it). The image is the *webserver*
+binary (distroless, `linux/amd64`); method: `POST /check_bpmn` with
+`{bpmn_file_content, properties_to_be_checked:[Safeness, OptionToComplete, ProperCompletion, NoDeadActivities]}`
+→ JSON `{property_results[].fulfilled, unsupported_elements[]}`.
+
+- **The exit-0 trap is confirmed**: the API returns HTTP 200 even for violating *and*
+  unsupported models — the verdict must come from the JSON body. `tools/check-soundness.mjs`
+  does exactly this. All files returned in < 100 ms.
+
+| Model | Result |
+|---|---|
+| tumor-board, diagnostic | analyzed → **NoDeadActivities violated** (dead activities) |
+| molecular-tumor-board | analyzed → **OptionToComplete + NoDeadActivities violated** |
+| aftercare, treatment | **inconclusive** — unsupported `inclusiveGateway` (OR) + `intermediateCatchEvent` |
+| overarching, patient-consultation | **inconclusive** — unsupported `intermediateCatchEvent` (timer/message wait) |
+
+**Findings:**
+- The analyzer's **supported subset excludes OR-gateways and `intermediateCatchEvent`s**,
+  both of which these models use → **4 of 7 are inconclusive today**. This overlaps the
+  existing SYN-5 (no-OR) defect and the timer/message-wait modelling.
+- The **3 analyzable models all violate soundness** (dead activities; molecular also no
+  option-to-complete) — consistent with the 99 bpmnlint structural defects (disconnected /
+  implicit-start activities are dead). **No false pass.**
+- **Timing** is not yet a concern for the supported subset, but the large overarching
+  pathway was never actually explored (it short-circuited on unsupported events at ~5 ms),
+  so its state-space cost is **untested**. The webserver runs **without POR**; if a large
+  *supported* model is analysed later and blows up, switch to the CLI with `--por` (needs a
+  CLI image build).
+
 ## Consequences / scope boundaries
 
-- After a green pilot: add `tools/check-soundness.mjs` (Docker-digest-pinned + result
-  parsing + inconclusive fallback) and a `bpmn-soundness` CI job; flip STR-1…STR-4 in the
-  Protokoll pre-filler from `HUMAN-INPUT-NEEDED` to tool-decided.
+- **Done (this PR):** `tools/check-soundness.mjs` (JSON result-parsing + INCONCLUSIVE
+  fallback + `--strict`), `npm run check:soundness`, the `bpmn-soundness` skill, and an
+  **advisory** (non-blocking) `soundness.yml` CI job using the pinned image.
+- **Deferred until the remodel:** a *blocking* gate and flipping STR-1…STR-4 in the
+  Protokoll from `HUMAN-INPUT-NEEDED` to tool-decided — premature while 4/7 models are
+  inconclusive (OR-gateways + catch events) and the analyzable ones violate on pre-existing
+  defects. After the OR-gateway/structural remodel, re-run and consider `--strict`.
 - **Inter-process soundness is NOT covered** by checking the 7 files independently: the
   overarching pathway calls sub-pathways via Call Activities; composition correctness
   stays a human-review item (CONVENTIONS §8.2 clinical validation).

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "check:roundtrip": "node tools/moddle-roundtrip.mjs",
     "check:xsd": "bash tools/validate-xsd.sh",
     "check:conformance": "node tools/check-conformance.mjs",
+    "check:soundness": "node tools/check-soundness.mjs",
     "abnahme:protokoll": "node tools/abnahme-protokoll.mjs"
   },
   "devDependencies": {

--- a/skills/README.md
+++ b/skills/README.md
@@ -12,6 +12,7 @@ applies. All tool-specific files only point here — never copy a skill's body.
 | [`bpmn-acceptance`](bpmn-acceptance/SKILL.md) | preparing a formal Abnahme | `npm run abnahme:protokoll` → pre-filled Protokoll (never stamps acceptance) |
 | [`clinical-pathway-review`](clinical-pathway-review/SKILL.md) | reviewing a pathway for the SEM/PRA criteria | advisory findings only (LLM-judgment, read-only) |
 | [`model-inventory`](model-inventory/SKILL.md) | mapping what the model set contains | a Model Inventory Matrix (read-only) |
+| [`bpmn-soundness`](bpmn-soundness/SKILL.md) | checking STR-1…4 behavioural soundness | `npm run check:soundness` (advisory; needs the analyzer container) |
 
 ## How each tool consumes these skills
 
@@ -23,14 +24,13 @@ applies. All tool-specific files only point here — never copy a skill's body.
 - **Cursor / other AGENTS.md readers** — read the root [`AGENTS.md`](../AGENTS.md),
   whose "Agent skills" section lists the same trigger and gate command.
 
-## Planned (later phases — not in this repo yet)
+## Status notes
 
-These are designed but not shipped; they arrive with their backing tools:
-
-- **bpmn-soundness** — STR-1…4 behavioural soundness via an external model checker
-  (`rust_bpmn_analyzer`). Approach + pilot protocol in
-  [`docs/decisions/0003-soundness-tooling.md`](../docs/decisions/0003-soundness-tooling.md);
-  until piloted, STR-1…4 stay `HUMAN-INPUT-NEEDED` in the `bpmn-acceptance` Protokoll.
+- **bpmn-soundness** is shipped but **advisory**: its pilot (2026-06-25) found 4/7 models
+  inconclusive (unsupported OR-gateways + intermediate catch events) and the analyzable
+  ones violate on pre-existing defects, so STR-1…4 stay `HUMAN-INPUT-NEEDED` in the
+  `bpmn-acceptance` Protokoll and the CI job is non-blocking until the model remodel. See
+  [`docs/decisions/0003-soundness-tooling.md`](../docs/decisions/0003-soundness-tooling.md).
 
 ## Editing rule
 

--- a/skills/bpmn-soundness/SKILL.md
+++ b/skills/bpmn-soundness/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: bpmn-soundness
+description: Run the behavioural soundness check (Abnahme STR-1..4) on the pathway models via the rust_bpmn_analyzer model checker (pinned Docker image), classifying each model SOUND / VIOLATION / INCONCLUSIVE. Use to gather STR evidence. Advisory — an INCONCLUSIVE (unsupported elements) is never a pass, and the overall acceptance stays human.
+---
+
+# BPMN soundness (advisory)
+
+The verdict comes from the analyzer's JSON, **not** from "did the tool run" — the API
+returns HTTP 200 even for a violating or unsupported model (the exit-0 trap). The
+wrapper handles this; your job is to run it and read the result honestly.
+
+## Run
+
+Start the analyzer (pinned by digest), then run the wrapper:
+
+```bash
+docker run -d --platform linux/amd64 -p 8090:8080 \
+  tkra/rust_bpmn_analyzer@sha256:9d939b84e82ca0ef55e9b34847d55bacd32b293fc7ef670e53d37d2ebcd3778c
+SOUNDNESS_URL=http://localhost:8090/check_bpmn npm run check:soundness
+# add -- --strict to fail on a SUPPORTED model's violation
+```
+
+If the analyzer is not reachable, the wrapper skips (advisory, exit 0). In CI this runs
+non-blocking via `.github/workflows/soundness.yml` (the analyzer as a service container).
+
+## Interpreting results (per model)
+
+| Result | Meaning | Abnahme |
+|---|---|---|
+| **SOUND** | all four properties fulfilled | STR-1…4 evidence = OK |
+| **VIOLATION** | a supported model violates a property: OptionToComplete=STR-1, ProperCompletion=STR-2, NoDeadActivities=STR-3; a deadlock/livelock (STR-4) shows as OptionToComplete=✗ | a real STR finding — fix the model |
+| **INCONCLUSIVE** | model uses unsupported elements (`unsupported_elements`: OR-gateways, `intermediateCatchEvent`s) | **human review / remodel — NOT a pass** |
+
+## Hard rules
+
+- **Never** treat INCONCLUSIVE as sound, and never flip the `bpmn-acceptance` Protokoll
+  STR rows from `HUMAN-INPUT-NEEDED` to ✓ on an INCONCLUSIVE result.
+- As of the 2026-06-25 pilot, **4 of 7 models are inconclusive** (OR-gateways + catch
+  events) and the 3 analyzable ones violate on existing structural defects — so this is
+  **advisory** until the model remodel. See `docs/decisions/0003-soundness-tooling.md`.
+- Inter-process (Call Activity composition) soundness is **not** covered by checking the
+  files independently — that stays human review.

--- a/tools/check-soundness.mjs
+++ b/tools/check-soundness.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Behavioural soundness check (STR-1…STR-4) — ADVISORY by default.
+ *
+ * Talks to the `rust_bpmn_analyzer` webserver (a BPMN-specific model checker;
+ * github.com/timKraeuter/rust_bpmn_analyzer), pinned by image digest, over its
+ * `POST /check_bpmn` JSON API. For each `.bpmn` it classifies:
+ *
+ *   SOUND        — all four properties fulfilled
+ *   VIOLATION    — a supported model violates a property (the real finding):
+ *                    OptionToComplete=STR-1, ProperCompletion=STR-2,
+ *                    NoDeadActivities=STR-3, Safeness (1-safe, supports STR-2/4);
+ *                    a deadlock/livelock (STR-4) surfaces as OptionToComplete=✗
+ *   INCONCLUSIVE — the model uses elements outside the analyzer's supported subset
+ *                  (`unsupported_elements`); e.g. OR-gateways, intermediateCatchEvents.
+ *                  → human review, never a pass and never a hard block.
+ *   ERROR        — the analyzer could not parse the model (malformed; also caught by
+ *                  bpmnlint) → reported, non-blocking here.
+ *
+ * IMPORTANT (verified from the analyzer source): the API returns HTTP 200 even for a
+ * violating model — there is NO exit-code signal from the tool. This wrapper derives
+ * the verdict from `property_results[].fulfilled` / `unsupported_elements`. A naïve
+ * "did the tool run" check would always pass. See docs/decisions/0003.
+ *
+ * Start the analyzer (pinned digest) first, e.g.:
+ *   docker run -d --platform linux/amd64 -p 8090:8080 \
+ *     tkra/rust_bpmn_analyzer@sha256:9d939b84e82ca0ef55e9b34847d55bacd32b293fc7ef670e53d37d2ebcd3778c
+ *   SOUNDNESS_URL=http://localhost:8090/check_bpmn node tools/check-soundness.mjs
+ *
+ * Exit: 0 (advisory). With `--strict`, exit 1 if any SUPPORTED model has a VIOLATION
+ * (INCONCLUSIVE/ERROR never block — they mean "remodel / human review", not "unsound").
+ */
+import { readFileSync } from 'node:fs';
+import { resolveBpmnFiles } from './bpmn-files.mjs';
+
+// Default host port 8090 (matches the documented `docker run -p 8090:8080` and avoids
+// colliding with services commonly on 8080). Override with SOUNDNESS_URL.
+const URL = process.env.SOUNDNESS_URL || 'http://localhost:8090/check_bpmn';
+const PROPS = ['Safeness', 'OptionToComplete', 'ProperCompletion', 'NoDeadActivities'];
+const STRICT = process.argv.includes('--strict');
+const files = resolveBpmnFiles(process.argv.slice(2).filter((a) => !a.startsWith('--')));
+
+if (!files.length) {
+  console.log('soundness: no .bpmn files found — nothing to check.');
+  process.exit(0);
+}
+
+async function check(file) {
+  const body = JSON.stringify({ bpmn_file_content: readFileSync(file, 'utf8'), properties_to_be_checked: PROPS });
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), Number(process.env.SOUNDNESS_TIMEOUT_MS || 120000));
+  try {
+    const res = await fetch(URL, { method: 'POST', headers: { 'content-type': 'application/json' }, body, signal: ctrl.signal });
+    const text = await res.text();
+    let j = null;
+    try { j = JSON.parse(text); } catch { /* non-JSON */ }
+    if (!j) return { kind: 'ERROR', detail: `HTTP ${res.status} non-JSON` };
+    if ((j.unsupported_elements || []).length) {
+      return { kind: 'INCONCLUSIVE', detail: [...new Set(j.unsupported_elements)].join(', ') };
+    }
+    const viol = (j.property_results || []).filter((r) => !r.fulfilled);
+    if (viol.length) return { kind: 'VIOLATION', detail: viol.map((v) => `${v.property}${v.problematic_elements?.length ? ` [${v.problematic_elements.slice(0, 4).join(', ')}]` : ''}`).join('; ') };
+    return { kind: 'SOUND', detail: 'all properties fulfilled' };
+  } catch (e) {
+    if (e.name === 'AbortError') return { kind: 'ERROR', detail: 'timeout (state-space blowup — the webserver runs without POR)' };
+    return { kind: 'ERROR', detail: `analyzer unreachable: ${e.message}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Fail fast with guidance if the analyzer is not reachable at all.
+try {
+  await fetch(URL.replace(/\/check_bpmn$/, '/'), { method: 'GET', signal: AbortSignal.timeout(3000) });
+} catch {
+  console.log(`soundness: analyzer not reachable at ${URL}.`);
+  console.log('  Start it (pinned digest), then re-run — see the header of this file / docs/decisions/0003.');
+  console.log('  Skipping (advisory).');
+  process.exit(0);
+}
+
+const icon = { SOUND: '✓', VIOLATION: '✖', INCONCLUSIVE: '?', ERROR: '!' };
+let violations = 0;
+let inconclusive = 0;
+console.log(`soundness: checking ${files.length} file(s) via ${URL}\n`);
+for (const file of files) {
+  const r = await check(file);
+  if (r.kind === 'VIOLATION') violations++;
+  if (r.kind === 'INCONCLUSIVE' || r.kind === 'ERROR') inconclusive++;
+  console.log(`${icon[r.kind]} ${file}`);
+  console.log(`    ${r.kind}: ${r.detail}\n`);
+}
+
+console.log('---------------------------------------------------------------');
+console.log(`soundness: ${violations} violation(s), ${inconclusive} inconclusive/error, ${files.length - violations - inconclusive} sound.`);
+console.log('Note: INCONCLUSIVE = unsupported elements (OR-gateways, intermediate catch events) → human review / remodel, never a pass.');
+if (STRICT && violations) {
+  console.error('soundness: FAIL (--strict) — a supported model violates a soundness property.');
+  process.exit(1);
+}
+console.log(STRICT ? 'soundness: OK (--strict; no supported-model violations).' : 'soundness: advisory run complete (use --strict to fail on supported-model violations).');


### PR DESCRIPTION
## Summary

**Executed the ADR-0003 soundness pilot** (Abnahme STR-1…4) and shipped an advisory soundness check.

> 🥞 Stacked on #31 (base = `feat/repo-moddle-and-phase-4`). Stack: `#29 ← #30 ← #31 ← this`; auto-retargets down to `dev` as parents merge.

## Pilot — what happened

- **No source build needed:** the analyzer ([`timKraeuter/rust_bpmn_analyzer`](https://github.com/timKraeuter/rust_bpmn_analyzer)) publishes a Docker image. Pinned by digest `tkra/rust_bpmn_analyzer@sha256:9d939b84…`. Used its `POST /check_bpmn` JSON API.
- **The exit-0 trap is confirmed real:** the API returns **HTTP 200 even for violating *and* unsupported models** — there is no exit-code signal. The wrapper derives the verdict from `property_results[].fulfilled` / `unsupported_elements`. A naïve "did it run" check would always pass.

| Model | Pilot result |
|---|---|
| tumor-board, diagnostic | analyzed → **NoDeadActivities ✗** (dead activities) |
| molecular-tumor-board | analyzed → **OptionToComplete ✗ + NoDeadActivities ✗** |
| aftercare, treatment | **INCONCLUSIVE** — unsupported OR-gateways (+ catch events) |
| overarching, patient-consultation | **INCONCLUSIVE** — unsupported `intermediateCatchEvent`s |

**Key findings:** the analyzer's supported subset **excludes OR-gateways and `intermediateCatchEvent`s** (timer/message waits), both used here → **4/7 inconclusive today**; the 3 analyzable models **all violate soundness** on the same defects bpmnlint already flags (no false pass); timing was a non-issue for the supported subset (the big overarching short-circuited on unsupported events, so its state-space cost is **untested** — the webserver runs without POR).

## Shipped (all verified locally)

- **`tools/check-soundness.mjs`** + `npm run check:soundness` — classifies each model **SOUND / VIOLATION / INCONCLUSIVE / ERROR**, parses the JSON (handles the exit-0 trap), `--strict` blocks **only** on a *supported* model's violation, and **skips gracefully** if the analyzer isn't reachable. Default port 8090 (avoids the FHIR-on-8080 collision).
- **`bpmn-soundness` skill** + registration in `skills/README.md` / `AGENTS.md`.
- **`.github/workflows/soundness.yml`** — **advisory / non-blocking**, runs the pinned image as a service container.
- **ADR-0003 updated** with the pilot results + revised plan.

## Deliberately NOT changed
- STR-1…4 stay **`HUMAN-INPUT-NEEDED`** in the `bpmn-acceptance` Protokoll.
- The soundness gate is **advisory, not blocking** — premature while 4/7 are inconclusive and the analyzable ones violate on pre-existing defects. After the OR-gateway/structural remodel, re-run and consider `--strict`. (Inter-process/Call-Activity composition soundness stays human review regardless.)

## Test plan
- [x] Pilot run over all 7 models via the pinned image; results captured above.
- [x] Wrapper verified: correct classification, `--strict` exits 1 on a supported violation, graceful skip when unreachable (exit 0). Container torn down.
- [x] `npm run check:conformance` unchanged.
- [ ] Advisory CI job runs the service container on a real runner (expected: same classification, green/non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
