### PR TITLE
Guard: models are read-only for agents (SEM-6) + model-issues report-don't-fix workflow

### DIFF
--- a/.claude/hooks/guard-model-files.sh
+++ b/.claude/hooks/guard-model-files.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Model guard — PreToolUse hook (Claude Code).
+#
+# Blocks any attempt by a skill/agent to MODIFY a BPMN pathway model (`.bpmn`) or its
+# `.svg` export. The models are the clinically-validated artifact: every change must be
+# made by a human modeler and re-validated for face validity (Abnahme SEM-6). Agents are
+# READ-ONLY w.r.t. the models — if a tool/agent finds a problem with the BPMN XML it must
+# REPORT it (docs/model-issues/) and propose a GitHub issue, never edit the model.
+#
+# Covers the file-write tools (Write/Edit/MultiEdit/NotebookEdit) and the obvious Bash
+# write vectors (redirects, `sed -i`, `tee`) targeting a model file. Reading models is
+# always allowed. Exit 2 = deny (stderr is shown to the agent).
+
+input="$(cat)"
+
+deny() {
+  echo "BLOCKED by the model guard: $1" >&2
+  echo "Agents must NOT modify .bpmn pathway models or their .svg exports — the models are" >&2
+  echo "clinically validated (Abnahme SEM-6 face validity) and change only via a human" >&2
+  echo "modeler + re-validation. Report the issue in docs/model-issues/ and propose a GitHub" >&2
+  echo "issue (.github/ISSUE_TEMPLATE/bpmn-model-issue.md) instead. See AGENTS.md." >&2
+  exit 2
+}
+
+# 1) Direct file-write tools — block when the target path is a model artifact.
+if printf '%s' "$input" | grep -qE '"(file_path|notebook_path)"[[:space:]]*:[[:space:]]*"[^"]*\.(bpmn|svg)"'; then
+  deny "a write to a model file (.bpmn/.svg) was attempted."
+fi
+
+# 2) Bash write vectors — redirect / sed -i / tee targeting a model file (reads are fine).
+if printf '%s' "$input" | grep -qE '(>>?[[:space:]]*[^[:space:]"|&;<>]*\.(bpmn|svg))|(\bsed\b[^;&|]*(-i|--in-place)[^;&|]*\.(bpmn|svg))|(\btee\b[^;&|]*\.(bpmn|svg))'; then
+  deny "a shell command appears to write to a model file (.bpmn/.svg)."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-model-files.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bpmn-model-issue.md
+++ b/.github/ISSUE_TEMPLATE/bpmn-model-issue.md
@@ -1,0 +1,35 @@
+---
+name: BPMN model issue
+about: A defect or change request for a .bpmn pathway model (filed by a human after a tool/agent reported it)
+title: "[model] "
+labels: ["model", "needs-clinical-review"]
+---
+
+<!--
+The .bpmn models are the clinically-validated artifact. Changes are made ONLY by a human
+modeler and re-validated for face validity (Abnahme SEM-6). Skills/agents REPORT issues to
+docs/model-issues/ and never edit a model. Fill this in from a docs/model-issues/ finding.
+-->
+
+### Affected model(s)
+
+<!-- e.g. lung-cancer_treatment-subpathway.bpmn -->
+
+### What was found
+
+<!-- the problem; paste the tool/agent evidence: bpmnlint / metrics / soundness output, element ids -->
+
+### Abnahme criteria affected
+
+<!-- e.g. SYN-5 (no OR-gateway), STR-1 (option to complete), STR-3 (no dead activities), SYN-2 (one start/end) -->
+
+### Suggested remodeling (for a human modeler)
+
+<!-- proposed fix — NOT to be applied by an agent -->
+
+### Done when
+
+- [ ] Remodeled by a human modeler
+- [ ] `.svg` re-exported and committed alongside the `.bpmn`
+- [ ] `npm run check:conformance` (and, if relevant, `npm run check:soundness`) re-run
+- [ ] Face validity re-confirmed (Abnahme **SEM-6**) if the clinical meaning changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,15 @@ Claude Code discovers them via `.claude/skills` → `../skills`; Codex/Copilot v
 
 ## Hard rules (do not violate)
 
+- **🔒 NEVER modify a `.bpmn` model or its `.svg` export.** The models are the
+  clinically-validated artifact (Abnahme **SEM-6** face validity); changes are made only
+  by a **human modeler** and re-validated. Agents are **read-only** w.r.t. the models —
+  this also forbids renaming, reformatting, `sed -i`, and redirect/`tee` writes. Found a
+  BPMN-XML issue? **Report it** in [`docs/model-issues/`](docs/model-issues/) with a
+  ready-to-file GitHub-issue suggestion ([template](.github/ISSUE_TEMPLATE/bpmn-model-issue.md)) —
+  never fix it. Enforced for Claude Code by the `guard-model-files` PreToolUse hook
+  (`.claude/hooks/guard-model-files.sh`, wired in `.claude/settings.json`); other tools
+  must honor it. (Humans editing models follow `CONTRIBUTING.md`.)
 - **No real patient data.** Use only synthetic / abstract pathway content. Never
   commit patient data, even realistic-looking.
 - **Not for clinical use.** Do not remove or weaken `DISCLAIMER.md` or the README

--- a/docs/model-issues/2026-06-25-baseline.md
+++ b/docs/model-issues/2026-06-25-baseline.md
@@ -1,0 +1,79 @@
+# Baseline model findings — 2026-06-25
+
+Discovered by the conformance gate, the model-metrics check, and the soundness pilot while
+building the tooling. **These are reports, not fixes** — a human modeler addresses each via
+a GitHub issue (template `bpmn-model-issue`) and re-validates (Abnahme SEM-6). Evidence is
+reproducible: `npm run check:conformance`, `npm run check:metrics`, and `npm run check:soundness`
+(with the analyzer container, see `docs/decisions/0003`).
+
+> Suggested labels for all: `model`. Per-issue extras noted below.
+
+---
+
+### Issue 1 — Replace the 4 OR-gateways with XOR/AND (SYN-5)
+
+- **Affected:** `lung-cancer_treatment-subpathway.bpmn` (`Gateway_18pkxio`, `Gateway_19kiq8e`),
+  `lung-cancer_aftercare-subpathway.bpmn` (`Gateway_04r56n3`, `Gateway_1tvjymy`).
+- **Found:** `bpmn:InclusiveGateway` present — `metrics` SYN-5 (blocking), bpmnlint
+  `no-inclusive-gateway`=error, and the soundness analyzer lists them as *unsupported*.
+- **Abnahme:** SYN-5 (no OR-gateway); CONVENTIONS R5.
+- **Suggested remodeling:** convert each inclusive gateway to explicit XOR (mutually exclusive
+  conditions) or AND (true parallelism). Unblocks soundness analysis for these two files.
+- **Labels:** `model`, `conformance`, `needs-clinical-review`.
+
+### Issue 2 — Fix structural correctness defects (disconnected nodes, implicit/missing start-end, labels) + dead activities
+
+- **Affected:** all sub-pathways (99 bpmnlint errors). Dead activities (soundness `NoDeadActivities`):
+  `diagnostic` (`Activity_063n77a, 0dmkmqr, 0u7tiem, 11j60zy`), `molecular-tumor-board`
+  (`Activity_11na49y, 1kyvkmk, 1phtl9y, 1s1obtx`), `tumor-board` (`Activity_07zzmzl, 09vqotg, 0k6eg9w, 0yme8s3`).
+- **Found:** bpmnlint `no-disconnected`, `no-implicit-start`/`no-implicit-end`,
+  `start-event-required`/`end-event-required`, `label-required`, `single-blank-start-event`
+  (overarching); soundness `NoDeadActivities` violated on the analyzable files (disconnected ⇒ dead).
+- **Abnahme:** SYN-2 (one start/end), STR-3 (no dead activities), SYN-3 (labels).
+- **Suggested remodeling:** connect orphaned activities into the flow (or remove them), add the
+  missing start/end events, label unlabelled gateways. Consider splitting per sub-pathway issue.
+- **Labels:** `model`, `conformance`, `soundness`.
+
+### Issue 3 — `molecular-tumor-board`: no option-to-complete (STR-1)
+
+- **Affected:** `lung-cancer_molecular-tumor-board-subpathway.bpmn`.
+- **Found:** soundness `OptionToComplete` = ✗ — at least one run cannot reach an end event
+  (a deadlock/livelock, STR-4 manifests here). A **Muss** criterion.
+- **Abnahme:** STR-1 (option to complete), STR-4 (no deadlock/livelock).
+- **Suggested remodeling:** inspect for mismatched gateway pairing (e.g. AND-split joined by an
+  XOR, or an unreachable join) using the analyzer's counter-example; re-pair gateways by type.
+- **Labels:** `model`, `soundness`, `needs-clinical-review`.
+
+### Issue 4 — Unify the BPMN namespace prefix (`bpmn:` vs `bpmn2:`)
+
+- **Affected:** `aftercare` + `overarching` use `bpmn2:`; the other five use `bpmn:`.
+- **Found:** `metrics` prefix-hygiene report.
+- **Abnahme:** none directly (consistency / SYN-1 hygiene).
+- **Suggested remodeling:** re-export all models with a single, consistent root prefix (`bpmn:`).
+  Cosmetic but eases review and tooling.
+- **Labels:** `model`, `housekeeping`.
+
+### Issue 5 — Resolve empty / stub processes
+
+- **Affected:** `diagnostic` (`Process_0bdppus`, `Process_1cffczp`), `patient-consultation`
+  (`Process_168oe6g`, `Process_0emc66x`) — extra `<process>` elements beyond the main one.
+- **Found:** bpmnlint `start-event-required` / `end-event-required` reported against these
+  process ids (they contain no start/end), i.e. empty black-box participant processes.
+- **Abnahme:** SYN-2; PRA-3 (relevance).
+- **Suggested remodeling:** either model the participant process, collapse it to a black-box
+  pool (no internal process), or remove it if unused.
+- **Labels:** `model`, `conformance`.
+
+### Issue 6 — Decide modelling of intermediate catch events + decompose the overarching pathway (SYN-2/SYN-4, soundness analyzability)
+
+- **Affected:** `overarching` (`Event_06iq4pa, 1884p82, 0t8i28j`), `aftercare`
+  (`Event_1f3bojn, 08adr55`), `patient-consultation` (`Event_0wmvigt`) carry
+  `intermediateCatchEvent`s the soundness analyzer does not support; `overarching` also has
+  **5 start events** (SYN-2) and **140 flow elements** (> 50, SYN-4).
+- **Found:** soundness *INCONCLUSIVE* (unsupported `intermediateCatchEvent`); `metrics` SYN-2/SYN-4.
+- **Abnahme:** SYN-2, SYN-4; affects STR analyzability.
+- **Suggested remodeling:** a modelling decision — decompose the overarching pathway via Call
+  Activities (≤ 50 elements/level, single start), and decide how timer/message waits are
+  represented so the soundness checker can analyse them (or scope soundness to the control-flow
+  subset). Needs clinical + modelling input.
+- **Labels:** `model`, `conformance`, `soundness`, `needs-clinical-review`.

--- a/docs/model-issues/README.md
+++ b/docs/model-issues/README.md
@@ -1,0 +1,27 @@
+# Model issues — report, don't fix
+
+The `.bpmn` pathway models are the **clinically-validated artifact**. **No skill or agent
+may modify a model** (`.bpmn` or its `.svg`) — every change is made by a **human modeler**
+and re-validated for face validity (Abnahme **SEM-6**). See `AGENTS.md` (Hard rules) and the
+`guard-model-files` PreToolUse hook (`.claude/hooks/guard-model-files.sh`).
+
+When a tool or agent finds a problem with the BPMN XML, it records it **here** as a finding
+plus a **ready-to-file GitHub issue suggestion** — it does **not** touch the model. A human
+then triages, files the issue (template:
+[`.github/ISSUE_TEMPLATE/bpmn-model-issue.md`](../../.github/ISSUE_TEMPLATE/bpmn-model-issue.md)),
+and a modeler fixes + re-validates.
+
+## Workflow
+
+1. **Tool/agent** finds a BPMN-XML problem → appends or adds a finding under this folder
+   (with evidence + a suggested issue). Never edits the model.
+2. **Human** reviews the finding and files a GitHub issue (using the suggestion + template).
+3. **Human modeler** remodels, re-exports the `.svg`, re-runs the gate
+   (`npm run check:conformance`, and `npm run check:soundness` where relevant), and
+   re-confirms face validity (SEM-6) if the clinical meaning changed.
+
+## Findings
+
+- [2026-06-25 — baseline findings](2026-06-25-baseline.md) — defects discovered while
+  building the tooling: OR-gateways, structural correctness, dead activities, namespace
+  prefixes, stub processes, and soundness-unsupported events.

--- a/skills/bpmn-acceptance/SKILL.md
+++ b/skills/bpmn-acceptance/SKILL.md
@@ -5,6 +5,13 @@ description: Prepare a pre-filled Abnahme (acceptance) Protokoll for the lung-ca
 
 # BPMN acceptance (Protokoll pre-filler)
 
+> **🔒 Model guard — read-only.** Never edit or modify a `.bpmn` model or its `.svg` export.
+> The models are clinically validated (Abnahme **SEM-6** face validity) and change only via a
+> human modeler + re-validation. Found a BPMN-XML problem while assembling evidence? **Report
+> it** in [`docs/model-issues/`](../../docs/model-issues/) and propose a GitHub issue
+> ([template](../../.github/ISSUE_TEMPLATE/bpmn-model-issue.md)) — do not change the model.
+> Enforced in Claude Code by the `guard-model-files` PreToolUse hook.
+
 You assemble **evidence**, you do **not** approve. The Abnahme instrument
 (`docs/governance/`) decides acceptance via three gates — Technical (tools),
 Clinical (expert consensus), Pragmatic (joint walkthrough) — and only humans sign off.

--- a/skills/bpmn-conformance/SKILL.md
+++ b/skills/bpmn-conformance/SKILL.md
@@ -5,6 +5,14 @@ description: Validate the lung-cancer pathway .bpmn models for BPMN 2.0 structur
 
 # BPMN conformance
 
+> **🔒 Model guard — read-only.** Never edit, reformat, or otherwise modify a `.bpmn`
+> model or its `.svg` export, *not even to fix an issue this skill finds*. The models are
+> clinically validated (Abnahme **SEM-6** face validity) and change only via a human
+> modeler + re-validation. Found a BPMN-XML problem? **Report it** in
+> [`docs/model-issues/`](../../docs/model-issues/) and propose a GitHub issue
+> ([template](../../.github/ISSUE_TEMPLATE/bpmn-model-issue.md)) — do not change the model.
+> Enforced in Claude Code by the `guard-model-files` PreToolUse hook.
+
 The decision is made by deterministic CLI tools, **not** by you. Your job is to
 **run them, read their reports, and explain failures** — never to hand-wave a pass.
 
@@ -38,9 +46,11 @@ Scope to specific files by appending paths, e.g. `npm run check:metrics -- lung-
 
 ## Interpreting results
 
-- **bpmnlint error** → a real structural defect (or an OR-gateway). Fix the diagram.
-- **metrics ✖ SYN-5** → an `InclusiveGateway`/`ComplexGateway` is present — remodel to
-  XOR/AND (CONVENTIONS R5) or document the deviation in the Abnahme Protokoll.
+- **bpmnlint error** → a real structural defect (or an OR-gateway). It needs a human
+  modeler — **report it** (see the Model guard above); do not edit the model yourself.
+- **metrics ✖ SYN-5** → an `InclusiveGateway`/`ComplexGateway` is present. A human modeler
+  must remodel it to XOR/AND (CONVENTIONS R5); **report it** via `docs/model-issues/` and the
+  Abnahme Protokoll — do not edit the model.
 - **metrics ⚠** (SYN-2/SYN-4/lanes/prefix) → advisory; a reviewer adjudicates
   intentional multi-start, orchestration size, etc. Not a build failure.
 - **roundtrip `note: extension content dropped`** → expected today: no `cp:`/`i18n:`

--- a/skills/bpmn-soundness/SKILL.md
+++ b/skills/bpmn-soundness/SKILL.md
@@ -5,6 +5,14 @@ description: Run the behavioural soundness check (Abnahme STR-1..4) on the pathw
 
 # BPMN soundness (advisory)
 
+> **🔒 Model guard — read-only.** Never edit, reformat, or otherwise modify a `.bpmn`
+> model or its `.svg` export, *not even to fix a violation this skill finds*. The models are
+> clinically validated (Abnahme **SEM-6** face validity) and change only via a human
+> modeler + re-validation. Found a BPMN-XML problem? **Report it** in
+> [`docs/model-issues/`](../../docs/model-issues/) and propose a GitHub issue
+> ([template](../../.github/ISSUE_TEMPLATE/bpmn-model-issue.md)) — do not change the model.
+> Enforced in Claude Code by the `guard-model-files` PreToolUse hook.
+
 The verdict comes from the analyzer's JSON, **not** from "did the tool run" — the API
 returns HTTP 200 even for a violating or unsupported model (the exit-0 trap). The
 wrapper handles this; your job is to run it and read the result honestly.
@@ -28,7 +36,7 @@ non-blocking via `.github/workflows/soundness.yml` (the analyzer as a service co
 | Result | Meaning | Abnahme |
 |---|---|---|
 | **SOUND** | all four properties fulfilled | STR-1…4 evidence = OK |
-| **VIOLATION** | a supported model violates a property: OptionToComplete=STR-1, ProperCompletion=STR-2, NoDeadActivities=STR-3; a deadlock/livelock (STR-4) shows as OptionToComplete=✗ | a real STR finding — fix the model |
+| **VIOLATION** | a supported model violates a property: OptionToComplete=STR-1, ProperCompletion=STR-2, NoDeadActivities=STR-3; a deadlock/livelock (STR-4) shows as OptionToComplete=✗ | a real STR finding — **report it** (a human modeler fixes the model) |
 | **INCONCLUSIVE** | model uses unsupported elements (`unsupported_elements`: OR-gateways, `intermediateCatchEvent`s) | **human review / remodel — NOT a pass** |
 
 ## Hard rules

--- a/skills/clinical-pathway-review/SKILL.md
+++ b/skills/clinical-pathway-review/SKILL.md
@@ -5,6 +5,13 @@ description: Advisory, read-only review of a lung-cancer BPMN pathway against th
 
 # Clinical pathway review (advisory)
 
+> **🔒 Model guard — read-only.** Never edit or modify a `.bpmn` model or its `.svg` export.
+> The models are clinically validated (Abnahme **SEM-6** face validity) and change only via a
+> human modeler + re-validation. Surface findings as candidates and **report** any BPMN-XML
+> problem in [`docs/model-issues/`](../../docs/model-issues/) with a GitHub-issue suggestion
+> ([template](../../.github/ISSUE_TEMPLATE/bpmn-model-issue.md)) — never change the model.
+> Enforced in Claude Code by the `guard-model-files` PreToolUse hook.
+
 You produce **evidence and questions for the human reviewers**, not verdicts. The
 clinical and pragmatic acceptance gates are decided by people (see `docs/governance/`).
 This is the only skill in the repo that is LLM-judgment rather than a deterministic

--- a/skills/model-inventory/SKILL.md
+++ b/skills/model-inventory/SKILL.md
@@ -5,6 +5,13 @@ description: Produce a Markdown inventory matrix of the BPMN pathway models (the
 
 # Model inventory
 
+> **🔒 Model guard — read-only.** Never edit or modify a `.bpmn` model or its `.svg` export.
+> The models are clinically validated (Abnahme **SEM-6** face validity) and change only via a
+> human modeler + re-validation. If you notice a BPMN-XML problem while inventorying, **report
+> it** in [`docs/model-issues/`](../../docs/model-issues/) with a GitHub-issue suggestion
+> ([template](../../.github/ISSUE_TEMPLATE/bpmn-model-issue.md)) — never change the model.
+> Enforced in Claude Code by the `guard-model-files` PreToolUse hook.
+
 Build a first-pass **Feature/Model Inventory Matrix** across the seven `.bpmn` files
 so a reviewer can see the whole pathway set at a glance. Read-only.
 


### PR DESCRIPTION
## Summary

Adds an **enforced guard** so no skill/agent ever modifies a `.bpmn` pathway model or its `.svg` export, plus a **report-don't-fix** workflow for BPMN-XML issues. Rationale: the models are the clinically-validated artifact — every change must go through a human modeler and be re-validated for face validity (Abnahme **SEM-6**).

> 🥞 Stacked on #32. Stack: `#29 ← #30 ← #31 ← #32 ← this`; auto-retargets to `dev` as parents merge.

## The guard (enforced, not just documented)

- **`.claude/hooks/guard-model-files.sh`** (PreToolUse, wired in `.claude/settings.json`) — blocks `Write`/`Edit`/`MultiEdit`/`NotebookEdit` to `.bpmn`/`.svg` **and** the obvious Bash write vectors (`>`/`>>` redirects, `sed -i`, `tee`) targeting a model. **Reads are always allowed.** Tested across block/allow cases (sed-i variants block; `cat`/`grep`/tool-arg reads pass).
- **Read-only guard block added to all 5 skills** (`bpmn-conformance`, `bpmn-acceptance`, `bpmn-soundness`, `clinical-pathway-review`, `model-inventory`).
- **`AGENTS.md` hard rule** (top of the list): never modify a model; report instead.

## "Don't harm the guard" — audit of #29–#32 ✅

Per your follow-up, I checked the earlier PRs don't undermine the guard:
- **No tool/script writes a model** — `moddle-roundtrip`'s `toXML` stays in memory (no `writeFile`); no redirect/`sed -i`/`tee` to `.bpmn`/`.svg` anywhere in `tools/` or workflows.
- **No workflow auto-commits/pushes** to the repo (release-please only touches `version.txt`/`CHANGELOG`).
- **Corrected latent harm:** three skills said *"fix the diagram" / "fix the model" / "remodel"* — reworded to *"report it; a human modeler fixes the model"* so the skills can't nudge an agent into editing.

## Report-don't-fix workflow

- **`docs/model-issues/`** — where tools/agents record BPMN-XML problems (with evidence + a ready-to-file issue suggestion) instead of editing. Includes **`2026-06-25-baseline.md`**: the real defects found while building the tooling, written up as **6 ready-to-file issues** (OR-gateways, structural correctness + dead activities, molecular no-option-to-complete, prefix unification, stub processes, intermediate-catch-events + overarching decomposition). This is effectively the remodel backlog.
- **`.github/ISSUE_TEMPLATE/bpmn-model-issue.md`** — issue form (affected model, evidence, Abnahme criteria, suggested remodeling, a "done when" checklist incl. SEM-6 re-validation).

## Notes / scope
- The hook protects the pathway repo when it's the active project in Claude Code; for other tools the `AGENTS.md` rule + skill guards apply. Humans editing models still follow `CONTRIBUTING.md` (the guard is agent-scoped).
- No tooling/gate behaviour changed: `npm run check:conformance` output is unchanged.

## Test plan
- [x] Hook block/allow matrix verified (Write/Edit/Bash; sed-i/redirect/tee block; reads allow).
- [x] `.claude/settings.json` is valid JSON; hook is executable.
- [x] Audit: no earlier-PR tool/workflow writes a model.
- [x] `npm run check:conformance` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
