### PR TITLE
Bilingual Abnahme docs (DE+EN, change-tracked) + language policy + bilingual issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bpmn-model-issue.md
+++ b/.github/ISSUE_TEMPLATE/bpmn-model-issue.md
@@ -1,35 +1,44 @@
 ---
-name: BPMN model issue
-about: A defect or change request for a .bpmn pathway model (filed by a human after a tool/agent reported it)
+name: BPMN model issue / BPMN-Modellproblem
+about: "EN: Report a defect/change request for a .bpmn pathway model. · DE: Defekt/Änderungswunsch zu einem .bpmn-Patientenpfadmodell melden."
 title: "[model] "
 labels: ["model", "needs-clinical-review"]
 ---
 
 <!--
-The .bpmn models are the clinically-validated artifact. Changes are made ONLY by a human
-modeler and re-validated for face validity (Abnahme SEM-6). Skills/agents REPORT issues to
+EN: The .bpmn models are the clinically-validated artifact. Changes are made ONLY by a human
+modeler and re-validated for face validity (Abnahme SEM-6). Skills/agents report to
 docs/model-issues/ and never edit a model. Fill this in from a docs/model-issues/ finding.
+DE: Die .bpmn-Modelle sind das klinisch validierte Artefakt. Änderungen erfolgen NUR durch
+eine:n menschliche:n Modellierer:in und werden auf Face Validity (Abnahme SEM-6) erneut
+validiert. Skills/Agenten melden nach docs/model-issues/ und bearbeiten nie ein Modell.
 -->
 
-### Affected model(s)
+### Affected model(s) · Betroffene(s) Modell(e)
 
 <!-- e.g. lung-cancer_treatment-subpathway.bpmn -->
 
-### What was found
+### What was found · Befund
 
-<!-- the problem; paste the tool/agent evidence: bpmnlint / metrics / soundness output, element ids -->
+<!--
+EN: the problem; paste tool/agent evidence (bpmnlint / metrics / soundness output, element ids).
+DE: das Problem; Tool-/Agenten-Belege einfügen (bpmnlint / metrics / soundness, Element-IDs).
+-->
 
-### Abnahme criteria affected
+### Abnahme criteria affected · Betroffene Abnahme-Kriterien
 
-<!-- e.g. SYN-5 (no OR-gateway), STR-1 (option to complete), STR-3 (no dead activities), SYN-2 (one start/end) -->
+<!-- e.g. SYN-5 (no OR-gateway), STR-1 (option to complete), STR-3 (no dead activities), SYN-2 -->
 
-### Suggested remodeling (for a human modeler)
+### Suggested remodeling (human modeler) · Vorgeschlagene Ummodellierung (durch Modellierer:in)
 
-<!-- proposed fix — NOT to be applied by an agent -->
+<!--
+EN: proposed fix — NOT to be applied by an agent.
+DE: Lösungsvorschlag — NICHT durch eine:n Agenten umzusetzen.
+-->
 
-### Done when
+### Done when · Erledigt, wenn
 
-- [ ] Remodeled by a human modeler
-- [ ] `.svg` re-exported and committed alongside the `.bpmn`
-- [ ] `npm run check:conformance` (and, if relevant, `npm run check:soundness`) re-run
-- [ ] Face validity re-confirmed (Abnahme **SEM-6**) if the clinical meaning changed
+- [ ] Remodeled by a human modeler · Durch Modellierer:in umgesetzt
+- [ ] `.svg` re-exported & committed · `.svg` neu exportiert & committet
+- [ ] `npm run check:conformance` (and · und `npm run check:soundness`) re-run
+- [ ] Face validity re-confirmed (Abnahme **SEM-6**) if the clinical meaning changed · Face Validity (SEM-6) erneut bestätigt, falls sich die klinische Bedeutung geändert hat

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,11 @@ consensus. The automatable criteria (SYN-1/2/4/5, STR-1..4) are tooled; the clin
 - **Declared conformance class: Analytic** (minus OR-gateways) — see `docs/decisions/0001`.
 - **Decompose** levels > ~50 elements via Call Activities (SYN-4).
 - **Conventional Commits**; scope = the pathway file (`feat(aftercare)!: …`, `docs(overarching): …`).
+- **Language:** the repo default is **German** (README, CONVENTIONS, governance instrument).
+  **Technical documentation is written in English** (ADRs in `docs/decisions/`, this file,
+  `CONTRIBUTING.md`, `docs/model-issues/`, tool docstrings/comments). The Abnahme governance
+  instrument (`docs/governance/`) is **bilingual** (DE original + EN translation, same version).
+  **Issue templates are always bilingual (DE + EN).**
 
 ## Branching and pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,23 @@ the [governance instrument](docs/governance/): a technical gate (tools), a clini
 gate (expert consensus), and a pragmatic gate (joint walkthrough), recorded in a
 signed Protokoll. Tools prepare evidence; humans decide.
 
+## Reporting issues
+
+Report bugs, model defects, and change requests via the repository's **GitHub issue tracker**
+(the *Issues* tab): <https://github.com/forschungsgruppe-digital-health/mihub-lung-cancer-pathway/issues>.
+Use the provided templates — e.g. **BPMN model issue** for a problem with a `.bpmn` model.
+Issue templates are bilingual (DE + EN). For BPMN-XML problems surfaced by a tool or agent,
+see [`docs/model-issues/`](docs/model-issues/): tools/agents record findings there (they never
+edit a model), and a human files the issue from that finding.
+
+## Language
+
+The repository default language is **German** (README, `CONVENTIONS.md`, the governance
+instrument). **Technical documentation is in English** (ADRs, `AGENTS.md`, this file,
+`docs/model-issues/`). The Abnahme governance instrument (`docs/governance/`) is **bilingual**
+(German original + English translation, kept at the same version). New **issue templates are
+always provided in both languages**.
+
 ## Questions
 
 Open a [GitHub issue](https://github.com/forschungsgruppe-digital-health/mihub-lung-cancer-pathway/issues)

--- a/docs/governance/CHANGELOG.md
+++ b/docs/governance/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog — Abnahme (acceptance) instrument
+
+Tracks changes to the governance/acceptance documents in this folder. **These documents are
+draft and not final — expect change.** Each document also carries its own `version` (in its
+front matter or header): the Checklist (the instrument) is the version reference; the Handout
+and the Protocol template are versioned independently.
+
+German is the authoritative original; the English `*.en.md` files are translations kept in
+sync at the same version. Changes follow Conventional Commits (`docs(governance): …`) and
+flow into the repo-level [CHANGELOG](../../CHANGELOG.md) via release-please. Format loosely
+follows [Keep a Changelog](https://keepachangelog.com/).
+
+## [Unreleased]
+
+### Added
+- English translations of all three documents (`*.en.md`) alongside the German originals;
+  German remains authoritative (2026-06-25).
+- This consolidated changelog and a version/status table in the folder README (2026-06-25).
+
+## Checklist (instrument) v0.3.1
+- BPMN4CP reference clarified: Revised = HICSS 2016 (pp. 3249–3258, DOI 10.1109/HICSS.2016.407);
+  BIBM-2014 and HICSS-2016 versions cited separately.
+
+## Checklist v0.3
+- Publication-ready instrument: front matter, derivation note, construct-to-source mapping,
+  evaluation plan, references, license/citation.
+
+## Checklist v0.2
+- Beginner-friendliness (glossary, check questions); full-text reconciliation of the core sources.
+
+## Checklist v0.1
+- Initial structure (dimensions, gates, sign-off).
+
+---
+
+### Companion documents
+
+- **Handout** v0.2 — per-criterion rationale + one lung-cancer example each; BPMN4CP appendix.
+- **Acceptance Protocol** (template) v1.0 — fill-in sign-off form (one protocol per acceptance).

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -3,11 +3,16 @@
 This folder holds the **Abnahme instrument** used to formally accept (sign off) a
 BPMN-modelled patient pathway, together with its rationale and a fill-in protocol.
 
-| File | Purpose |
-|---|---|
-| [`abnahme-checkliste-bpmn-patientenpfad.md`](abnahme-checkliste-bpmn-patientenpfad.md) | **The instrument (v0.3.1)** — the criteria, severities, methods, and gates. |
-| [`abnahme-handout-bpmn-patientenpfad.md`](abnahme-handout-bpmn-patientenpfad.md) | **Rationale + examples** — why each criterion exists (with sources) and one lung-cancer example per item. |
-| [`abnahme-protokoll-bpmn-patientenpfad.md`](abnahme-protokoll-bpmn-patientenpfad.md) | **Sign-off protocol** — fill in per acceptance; one protocol per acceptance event. |
+Each document is maintained **bilingually**: German is the authoritative original; the
+English `*.en.md` is a translation kept in sync at the same version (repo language policy in
+`AGENTS.md`). The documents are **draft / not final** — changes are tracked in
+[`CHANGELOG.md`](CHANGELOG.md) and via Conventional Commits (`docs(governance): …`).
+
+| Document | Version | DE (original) | EN (translation) |
+|---|---|---|---|
+| **Acceptance Checklist** — the instrument (criteria, severities, methods, gates) | 0.3.1 | [DE](abnahme-checkliste-bpmn-patientenpfad.md) | [EN](abnahme-checkliste-bpmn-patientenpfad.en.md) |
+| **Handout** — rationale + one lung-cancer example per criterion (with sources) | 0.2 | [DE](abnahme-handout-bpmn-patientenpfad.md) | [EN](abnahme-handout-bpmn-patientenpfad.en.md) |
+| **Acceptance Protocol** — fill-in sign-off form (one per acceptance) | 1.0 | [DE](abnahme-protokoll-bpmn-patientenpfad.md) | [EN](abnahme-protokoll-bpmn-patientenpfad.en.md) |
 
 ## How to read it
 

--- a/docs/governance/abnahme-checkliste-bpmn-patientenpfad.en.md
+++ b/docs/governance/abnahme-checkliste-bpmn-patientenpfad.en.md
@@ -1,0 +1,177 @@
+<!--
+English translation of `abnahme-checkliste-bpmn-patientenpfad.md` (German is the original/authoritative source).
+Provided for reference; keep both language versions in sync and at the same version.
+Status: draft — not final, likely to change. Change history: docs/governance/CHANGELOG.md.
+-->
+
+---
+title: "Acceptance Checklist for BPMN-Modelled Patient Pathways"
+short_title: "BPMN-CP Acceptance Instrument"
+version: "0.3.1"
+status: "Proposed artifact (DSR) – conceptually derived from kernel theories, not yet empirically validated"
+language: "EN"
+autor: "[Nachname, Initiale]"
+affiliation: "[Einrichtung]"
+orcid: "[ORCID]"
+lizenz: "CC BY 4.0"
+persistent_id: "[DOI/Zenodo nach Hinterlegung]"
+audience: "clinical and technical stakeholders; including modeling beginners"
+---
+
+# Acceptance Checklist for BPMN-Modelled Patient Pathways (v0.3.1)
+
+## Suggested citation
+
+> [Nachname, Initiale] ([Jahr]). *Abnahme-Checkliste für BPMN-modellierte Patientenpfade* (Version 0.3) [Evaluationsinstrument]. [Einrichtung]. [DOI].
+
+When used in a publication, please additionally cite the core sources named in the Construct-to-source mapping (§4).
+
+---
+
+## 1. Purpose and scope
+
+The instrument supports the **structured, traceable acceptance (release)** of a patient pathway modelled in BPMN by **clinical** and **technical** stakeholders. It is designed as a compact assessment grid (items with dichotomous / partly criteria-based checking) and is formulated as tested for intersectoral, oncological care pathways; the items are transferable independently of the domain.
+
+## 2. Methodological derivation (transparency)
+
+The items were **conceptually** synthesised from established kernel theories (in the sense of Hevner et al. 2004) of three strands and mapped to one another:
+
+1. **Generic conceptual model quality** — Guidelines of Modeling (Becker et al. 1995), SEQUAL (Lindland et al. 1994; Krogstie et al.), 7PMG (Mendling et al. 2010).
+2. **Clinical pathway validity** — operational pathway definition according to Kinsman et al. (2010); domain-specific modelling concepts according to BPMN4CP (Braun et al. 2014).
+3. **Technical correctness/executability** — conformance classes of the OMG BPMN 2.0 specification; soundness concept (van der Aalst; operationalised in Fahland et al. 2011).
+
+The acceptance logic follows the distinction between **verification vs. validation** and the SEQUAL separation of pragmatic quality by *social* (clinical) and *technical* audience group. The instrument is understood as a DSR artifact; for positioning and planned evaluation see §6.
+
+**Limitation.** This version is a theory-driven construction. An empirical validation (content validity, reliability, applicability) is pending (§6).
+
+---
+
+## 3. The instrument
+
+**Reading aid.** **Must** = knock-out criterion · **Should** = important, document deviation. **Check method:** **A** = automatic (tool) · **R** = visual check in review · **K** = consensus (Konsens). Tick off: `[x]` met · `[ ]` open. For technical terms see Mini glossary (§8).
+
+### A. Understandability & technical correctness — *technical acceptance*
+
+- [ ] **SYN-1** The BPMN **language scope (conformance class)** is declared and adhered to. 👉 *concretely:* Descriptive/Analytic/Common Executable named; only their elements used. *(Must · A)*
+- [ ] **SYN-2** **Exactly one start and one end event** per level. 👉 *concretely:* multiple ends only with justification. *(Must · A/R)*
+- [ ] **SYN-3** Activities as **verb + object**. 👉 *concretely:* "Report histology" instead of "Histology". *(Should · R)*
+- [ ] **SYN-4** No diagram overloaded (**≤ 50 symbols**); large pathways decomposed. 👉 *concretely:* outsource via Call Activity. *(Should · A)*
+- [ ] **SYN-5** **Cleanly paired** splits/joins, low node degree, **no OR gateway**. 👉 *concretely:* split/join of the same type (like brackets). *(Should · A/R)*
+- [ ] **STR-1** **Every run can reach the end** (no dead end). *(Must · A)*
+- [ ] **STR-2** **No open parallel branches at the end.** *(Must · A)*
+- [ ] **STR-3** **No dead/unreachable activities.** *(Must · A)*
+- [ ] **STR-4** **No deadlock/livelock** (gateway types correctly paired). *(Must · A)*
+
+### B. Clinical content validity — *clinical acceptance*
+
+- [ ] **SEM-1** **Multidisciplinary**: all participating disciplines visible as a lane. *(Must · R)*
+- [ ] **SEM-2** **Guideline/evidence reference** noted at important steps (e.g. S3 guideline / nNGM). *(Should\* · R)*
+- [ ] **SEM-3** **Essential treatment steps** complete (incl. restaging, follow-up care). *(Should\* · R)*
+- [ ] **SEM-4** Transitions tied to **deadlines/criteria**. *(Should\* · R)*
+- [ ] **SEM-5** **Target population/standardisation** delimited. *(Should\* · R)*
+- [ ] **SEM-6** **Face validity**: iteratively validated with clinical/domain experts until consensus. *(Must · K)*
+- [ ] **SEM-7** Relevant **domain artifacts** (resources, documents, quality indicators) captured. *(Should · R)*
+
+> **Kinsman gate (Must):** SEM-1 **and** ≥ 3 of 4 from {SEM-2…SEM-5}.
+
+### C. Understandability for both sides — *joint acceptance*
+
+- [ ] **PRA-1** Clinical and IT side **understand the model identically** (joint walkthrough). *(Must · R)*
+- [ ] **PRA-2** **Overview and technical detail view** available. *(Should · R)*
+- [ ] **PRA-3** **Relevance**: no superfluous elements. *(Should · R)*
+
+### Acceptance gates
+
+| Gate | Condition | Method |
+|---|---|---|
+| Technical | all Must in A (SYN-1, SYN-2, STR-1…4) | A + R |
+| Clinical | Kinsman gate **and** SEM-6 | R + K |
+| Pragmatic | PRA-1 | R |
+
+**Overall acceptance** only with all three gates. Document open Should items in the sign-off with measure/deadline.
+
+---
+
+## 4. Construct-to-source mapping (traceability)
+
+| ID | Construct / quality dimension | Core source(s) |
+|---|---|---|
+| SYN-1 | Language conformance (syntactic) | OMG BPMN 2.0 / ISO/IEC 19510 |
+| SYN-2 | Syntactic quality, model quality | Mendling et al. 2010 (G3); Lindland et al. 1994 |
+| SYN-3 | Label uniqueness (pragmatic) | Mendling et al. 2010 (G6) |
+| SYN-4 | Size/complexity → error risk | Mendling et al. 2010 (G7) |
+| SYN-5 | Structuredness, routing | Mendling et al. 2010 (G2/G4/G5) |
+| STR-1…4 | Soundness (semantic/technical) | van der Aalst; Fahland et al. 2011 |
+| SEM-1 | Multidisciplinarity (pathway definition) | Kinsman et al. 2010 (crit. 1); Braun et al. 2014 |
+| SEM-2 | Evidence/guideline grounding | Kinsman et al. 2010 (crit. 2) |
+| SEM-3 | Completeness of steps | Kinsman et al. 2010 (crit. 3) |
+| SEM-4 | Criteria-based progression | Kinsman et al. 2010 (crit. 4) |
+| SEM-5 | Standardisation/population | Kinsman et al. 2010 (crit. 5) |
+| SEM-6 | Semantic validity (face validity) | Lindland et al. 1994; Benevento et al. 2023 |
+| SEM-7 | Domain-specific concepts | Braun et al. 2014 |
+| PRA-1 | Pragmatic quality (dual audience) | Lindland et al. 1994; Krogstie et al. |
+| PRA-2 | Stakeholder-specific perspectives | Braun et al. 2014 |
+| PRA-3 | Relevance | Becker et al. 1995; Mendling et al. 2010 (G1) |
+
+---
+
+## 5. Application/reuse note
+
+The instrument is freely usable and adaptable under CC BY 4.0. When adapting (e.g. another indication), changed/added items should be marked as a deviation from this version (0.3) in order to preserve comparability.
+
+## 6. Planned evaluation (DSR positioning)
+
+A **formative → summative** evaluation trajectory is planned in the sense of FEDS (Venable et al. 2016), with method selection according to Prat et al. (2015):
+
+1. **Content validation (formative, artificial):** expert panel (clinical + technical), Lawshe CVR/CVI per item; items below the critical CVR are revised/removed.
+2. **Understandability/usability (formative):** cognitive walkthrough / think-aloud with modeling beginners.
+3. **Reliability & criterion validity (summative, naturalistic):** application to real pathways; interrater reliability (Cohen's/Fleiss' kappa) between independent reviewers; comparison with an expert gold standard.
+4. **Acceptance/utility (summative):** controlled comparison (with vs. without the instrument) regarding defect detection and perceived utility (Method Evaluation Model, Moody 2003 / UTAUT items).
+
+---
+
+## 7. References
+
+**Construct/core sources (reconciled at source level in this work):**
+
+- Becker, J.; Rosemann, M.; Schütte, R. (1995): Grundsätze ordnungsmäßiger Modellierung. *Wirtschaftsinformatik* 37(5), 435–445.
+- Lindland, O. I.; Sindre, G.; Sølvberg, A. (1994): Understanding quality in conceptual modeling. *IEEE Software* 11(2), 42–49. (Extension: Krogstie, J.; Lindland, O. I.; Sindre, G. 1995; Krogstie 2006.)
+- Mendling, J.; Reijers, H. A.; van der Aalst, W. M. P. (2010): Seven process modeling guidelines (7PMG). *Information and Software Technology* 52(2), 127–136.
+- Kinsman, L.; Rotter, T.; James, E.; Snow, P.; Willis, J. (2010): What is a clinical pathway? Development of a definition to inform the debate. *BMC Medicine* 8:31.
+- Object Management Group (2011): *Business Process Model and Notation (BPMN) Version 2.0* (corresp. ISO/IEC 19510:2013).
+- Fahland, D.; Favre, C.; Koehler, J.; Lohmann, N.; Völzer, H.; Wolf, K. (2011): Analysis on demand: Instantaneous soundness checking of industrial business process models. *Data & Knowledge Engineering* 70, 448–466.
+- Braun, R.; Schlieter, H.; Burwitz, M.; Esswein, W. (2014): BPMN4CP: Design and implementation of a BPMN extension for clinical pathways. *Proc. IEEE Int. Conf. on Bioinformatics and Biomedicine (BIBM)*, 9–16. — Revised: Braun, R.; Schlieter, H.; Burwitz, M.; Esswein, W. (2016): BPMN4CP Revised – Extending BPMN for Multi-perspective Modeling of Clinical Pathways. *49th Hawaii Int. Conf. on System Sciences (HICSS)*, 3249–3258, DOI 10.1109/HICSS.2016.407.
+- Benevento, E. et al. (2023): Process Modeling and Conformance Checking in Healthcare: A COVID-19 Case Study. In: *Process Mining Workshops*, Springer (LNBIP).
+
+**Methodological references (standard literature; verify citation details before submission — verified at source in the thread: Venable et al. 2016, Prat et al. 2015, Lawshe 1975):**
+
+- Hevner, A. R.; March, S. T.; Park, J.; Ram, S. (2004): Design Science in Information Systems Research. *MIS Quarterly* 28(1), 75–105.
+- Peffers, K.; Tuunanen, T.; Rothenberger, M. A.; Chatterjee, S. (2007): A Design Science Research Methodology for Information Systems Research. *JMIS* 24(3), 45–77.
+- Venable, J.; Pries-Heje, J.; Baskerville, R. (2016): FEDS: A Framework for Evaluation in Design Science Research. *European Journal of Information Systems* 25(1), 77–89.
+- Prat, N.; Comyn-Wattiau, I.; Akoka, J. (2015): A Taxonomy of Evaluation Methods for Information Systems Artifacts. *JMIS* 32(3), 229–267.
+- Sonnenberg, C.; vom Brocke, J. (2012): Evaluations in the Science of the Artificial. In: *DESRIST*, LNCS 7286, 381–397.
+- Lawshe, C. H. (1975): A Quantitative Approach to Content Validity. *Personnel Psychology* 28(4), 563–575.
+
+## 8. Mini glossary (for beginners)
+
+| Term | In one sentence |
+|---|---|
+| **Activity** | Work step; rounded rectangle. |
+| **Event** | Occurrence; circle (start = thin, end = thick). |
+| **Gateway** | Split/join; diamond. XOR = either/or, AND = parallel, OR = one *or several* (avoid). |
+| **Lane / Pool** | "Swimlane": shows who performs the step. |
+| **Token** | Imagined game piece that follows the arrows (for "playing through"). |
+| **Soundness** | No logical dead ends, blocked or unreachable points. |
+| **Call Activity** | Step that references an outsourced sub-model. |
+| **Conformance class** | Agreed BPMN language scope: Descriptive < Analytic < Common Executable. |
+
+## 9. Changelog
+
+- **v0.3.1** — BPMN4CP reference made precise: Revised = HICSS 2016 (pp. 3249–3258, DOI 10.1109/HICSS.2016.407); BIBM 2014 and HICSS 2016 versions cited separately.
+- **v0.3** — Publication-ready instrument version: front matter, derivation note, Construct-to-source mapping, evaluation plan, references, license/citation.
+- **v0.2** — Beginner suitability (glossary, check questions), full-text reconciliation of the core sources.
+- **v0.1** — First structure (dimensions, gates, sign-off).
+
+---
+
+*Rationale and one example per item: `abnahme-handout-bpmn-patientenpfad.md`. Status of the source check documented there.*

--- a/docs/governance/abnahme-handout-bpmn-patientenpfad.en.md
+++ b/docs/governance/abnahme-handout-bpmn-patientenpfad.en.md
@@ -1,0 +1,196 @@
+<!--
+English translation of `abnahme-handout-bpmn-patientenpfad.md` (German is the original/authoritative source).
+Provided for reference; keep both language versions in sync and at the same version.
+Status: draft — not final, likely to change. Change history: docs/governance/CHANGELOG.md.
+-->
+
+# Handout for the Acceptance Checklist: BPMN-modelled Patient Pathway
+
+**Purpose.** This document provides a traceable rationale for each acceptance criterion based on the sources and illustrates it with one example each from the lung-cancer context. The IDs are identical to those in the checklist. Technical terms are explained in the **mini-glossary of the checklist**.
+
+**Structure per criterion:** *Criterion* → *Rationale (source)* → *Example*.
+
+> Note on source verification: 7PMG, Kinsman, SEQUAL and soundness were checked **against the full text**; OMG BPMN 2.0 and BPMN4CP were checked against the specification/abstract and excerpt level (see verification status at the end).
+
+---
+
+## A. Understandability & technical correctness (technical acceptance)
+
+### SYN-1 · Conformance class declared and adhered to
+
+**Criterion.** The intended BPMN 2.0 language scope (Descriptive, Analytic, Common Executable) is defined, and the model uses only the elements permitted there.
+
+**Rationale (source).** The OMG specification BPMN 2.0 defines three process-modeling conformance subclasses that build on one another, each with a limited scope of elements and attributes. Without a declared target class it is not verifiable whether different tools interpret or serialise the model identically — inconsistencies in XML serialisation between tools are documented. Defining the class is what makes the technical acceptance objectifiable in the first place.
+
+**Example.** A pathway with a timer event ("molecular diagnostics within 14 days") and a message event ("findings to tumor board") exceeds **Descriptive**. The correct class is **Analytic**; if the pathway is later to be executed by an engine, **Common Executable** is required.
+
+### SYN-2 · One start/one end event per level
+
+**Criterion.** Every process level has exactly one start and one end event; multiple ends converge or are deliberately justified.
+
+**Rationale (source).** 7PMG guideline **G3** (Mendling, Reijers, van der Aalst 2010): The number of start/end events correlates positively with the probability of error. The authors explicitly name two further reasons: most workflow engines require a single start/end node, and exactly one start/end facilitates understanding **and** is what makes analyses such as the soundness check possible in the first place.
+
+**Example.** A pathway that ends in parallel in "Curative therapy initiated" and "Best supportive care initiated" converges on a common end event "Therapy decision documented" — instead of two loose ends.
+
+### SYN-3 · Verb-object labels
+
+**Criterion.** Activities are named as verb + object.
+
+**Rationale (source).** 7PMG guideline **G6**: In an experiment with 29 postgraduates (Eindhoven), verb-object labels were rated as significantly less ambiguous and more useful than nominal ("action-noun") labels. According to the authors, it is the only one of the common labelling rules that is operationalised and empirically supported.
+
+**Example.** Anti-pattern: "Histology", "Tumor board". Pattern: "**Report histology findings**", "**Present case at tumor board**". "Diagnostics" becomes "**Perform imaging**".
+
+### SYN-4 · ≤ 50 elements / decomposition
+
+**Criterion.** No diagram exceeds ~50 elements; larger pathways are decomposed via Call Activities.
+
+**Rationale (source).** 7PMG guideline **G7**: Size is a major driver of the probability of error; in a collection of ~2000 industrial models it exceeded 50 % beyond > 50 elements. For context: real modelling projects exhibit error rates of 10–20 % anyway. Decomposition keeps sub-models understandable and verifiable.
+
+**Example.** The block "molecular diagnostics" (sample acquisition, NGS request, reporting, release, follow-up presentation) is extracted as its own sub-process diagram and referenced in the main pathway as a Call Activity "Perform molecular diagnostics".
+
+### SYN-5 · Structure, minimal routing, no OR-gateways
+
+**Criterion.** The model is as block-structured as possible, the node degree is low, OR-gateways are avoided or justified.
+
+**Rationale (source).** 7PMG **G4** (ranked by 21 surveyed professional modellers as the most effective guideline): A model is *structured* if **every split connector has a join connector of the same type** — the authors compare this to **balanced brackets** (every opening one has a matching closing one). Additionally **G2** (a high node degree correlates strongly with errors) and **G5** (the OR-join semantics is ambiguous and leads to paradoxes/implementation problems). Note by the authors: apply G2 only in extreme cases, as it runs counter to G1 (fewer elements).
+
+**Example.** Instead of an OR-gateway "possibly radiation and/or chemotherapy", two explicit, cleanly paired splits with unambiguous conditions are modelled ("Stadium III → radiochemotherapy", "Stadium IV → systemic therapy").
+
+### STR-1…STR-4 · Soundness (logical freedom from errors)
+
+**Criterion.** The model is *sound*: every run can reach the end (STR-1), no active tokens remain at the end (STR-2), no dead/unreachable activities (STR-3), no deadlock/livelock (STR-4).
+
+**Rationale (source).** Soundness is the established correctness criterion for process models (van der Aalst), derived via the Petri-net properties liveness and boundedness. Fahland et al. (2011, *Data & Knowledge Engineering* 70, 448–466) show that these properties are practically instantaneously checkable in an automated way for realistic industrial models ("Analysis on demand"). Soundness is the objectifiable core of the technical acceptance — best checked by tool.
+
+**Example (deadlock, STR-4).** After "Complete staging", an **AND-split** opens two branches (pathology, radiology); they are then erroneously merged with an **XOR-join**. The XOR-join fires on the first arriving token, the second one remains stranded → STR-2 violated. Conversely, an **AND-join after an XOR-split** creates a deadlock (waits forever for a branch that was never activated). Rule: pair gateways of the same type.
+
+---
+
+## B. Clinical content validity (clinical acceptance)
+
+> Basis B.1: Kinsman, Rotter, James, Snow, Willis (2010): *What is a clinical pathway? Development of a definition to inform the debate.* **BMC Medicine** 8:31 — five criteria, developed in coordination with the European Pathways Association. Operationalisation (confirmed against the full text): criterion 1 (must) plus ≥ 3 of the remaining four.
+
+### SEM-1 · Multidisciplinary plan, roles as lanes
+
+**Criterion.** Structured, multidisciplinary treatment plan; all participating disciplines are represented.
+
+**Rationale (source).** Kinsman criterion 1 — the only mandatory one: Without represented multidisciplinarity it is, by definition, not a clinical pathway. BPMN4CP (Braun et al. 2014) emphasises that the activities shared across roles form the core of pathway modelling.
+
+**Example.** Lanes for **pulmonology, radiology, pathology, thoracic surgery, (haemato-)oncology, palliative medicine** and **patient**; the tumor board appears as a cross-role activity.
+
+### SEM-2 · Guideline/evidence reference
+
+**Criterion.** For each relevant step, the underlying guideline/evidence is named.
+
+**Rationale (source).** Kinsman criterion 2: A pathway "channels" the translation of guidelines/evidence into local structures. The reference makes clinical correctness verifiable.
+
+**Example.** "Request molecular diagnostics" carries an annotation referencing the **S3-Leitlinie Lungenkarzinom** or the **nNGM** recommendation; the source reference is documented in the review protocol.
+
+### SEM-3 · Completeness of the steps
+
+**Criterion.** The essential steps of the treatment course are represented.
+
+**Rationale (source).** Kinsman criterion 3 requires the steps to be detailed as an "inventory of actions". Gaps lead to undefined behaviour in care delivery.
+
+**Example.** Reviewers check that **restaging** and **structured aftercare** are also modelled after therapy initiation and are not implicitly assumed.
+
+### SEM-4 · Time frame / criteria-based progression
+
+**Criterion.** Transitions are tied to deadlines or explicit criteria.
+
+**Rationale (source).** Kinsman criterion 4: Steps are triggered when defined criteria are met — this distinguishes a pathway from a mere collection of activities.
+
+**Example.** Conditional gateway "**molecular findings complete?**"; in case of "no after 14 days", escalation via a timer event instead of undefined waiting.
+
+### SEM-5 · Target population / standardisation
+
+**Criterion.** Target population and standardisation goal are delimited.
+
+**Rationale (source).** Kinsman criterion 5: A pathway standardises the care of a **specific** population/problem. Without delimitation, completeness cannot be assessed.
+
+**Example.** Scope annotation: "**NSCLC, Stadium III–IV, first diagnosis**"; SCLC and recurrences are explicitly excluded.
+
+### SEM-6 · Clinical correctness / face validity (consensus)
+
+**Criterion.** The model has been validated iteratively with domain experts until consensus.
+
+**Rationale (source).** Validation ("the *right* model") relies on domain expertise — unlike the automatable verification. Documented approach: Benevento et al. (2023) validated their normative BPMN model qualitatively in several sessions with physicians from intensive/intermediate care and refined it until all agreed.
+
+**Example.** The pathway model is presented in two to three moderated sessions in the tumor board; change requests are incorporated in a versioned manner until the board unanimously approves it (protocol as proof of acceptance).
+
+### SEM-7 · Domain-specific artefacts (BPMN4CP)
+
+**Criterion.** Where applicable, resources, documents, goals and quality indicators are captured.
+
+**Rationale (source).** BPMN4CP (Braun et al. 2014; revised 2015/2016) deliberately extends BPMN with these CP-specific concepts, because generic BPMN does not represent them. They are deliberately distributed across perspective-specific sub-diagrams in order to master complexity (see appendix).
+
+**Example.** Attached to "Initiate systemic therapy" are: the required **document** (molecular pathology findings report), the required **resource** (bundle "imaging"), the **quality indicator** ("time from diagnosis to start of therapy").
+
+---
+
+## C. Understandability for both sides (joint acceptance)
+
+### PRA-1 · Understandability for clinical and technical audiences
+
+**Criterion.** The model is equally understandable for both audience groups.
+
+**Rationale (source).** SEQUAL (Lindland, Sindre, Sølvberg 1994; extended by Krogstie et al.) defines **pragmatic quality** as the correspondence between the model and the audience's interpretation — explicitly separated into *social* (here clinical) and *technical* audience. This very dual understandability is the joint acceptance criterion. (7PMG describes SEQUAL as valuable, but too abstract for beginners — which is why the checklist adds concrete 7PMG items.)
+
+**Example.** In the joint walkthrough, one clinical and one technical person each paraphrase the same pathway segment; if the interpretations diverge (e.g. the meaning of a gateway), the model or the label is sharpened.
+
+### PRA-2 · Stakeholder-specific partial views
+
+**Criterion.** Audience-appropriate partial views exist.
+
+**Rationale (source).** BPMN4CP assigns concepts to different perspectives/diagrams in order to provide diagrams suitable for the respective stakeholders (in essence). The same element can be represented differently (shape, level of detail) per diagram.
+
+**Example.** A **clinical overview view** (lanes, main steps, without technical attributes) and a **technical view** (data objects, message flows, execution attributes) of the same pathway.
+
+### PRA-3 · Relevance
+
+**Criterion.** No elements superfluous for the acceptance purpose.
+
+**Rationale (source).** GoM principle of **relevance** (Becker, Rosemann, Schütte 1995) and 7PMG **G1** ("as few elements as possible"): Superfluous elements increase cognitive load and the risk of error without yielding any insight. In the 7PMG example, applying G1 reduced the element count from 37 to 31 without changing the logic.
+
+**Example.** Purely decorative intermediate events or duplicated auxiliary activities that are irrelevant to the acceptance decision are removed or moved into a detail view.
+
+---
+
+## Appendix: Summary of the BPMN4CP paper
+
+**Sources (all: Chair of Wirtschaftsinformatik, esp. Systems Development, TU Dresden — confirmed via the TU Dresden research portal).**
+- Original: Braun, R.; Schlieter, H.; Burwitz, M.; Esswein, W. (2014): *BPMN4CP: Design and implementation of a BPMN extension for clinical pathways.* Proc. IEEE Int. Conf. on Bioinformatics and Biomedicine (BIBM), pp. 9–16.
+- Revised: Braun, R.; Schlieter, H.; Burwitz, M.; Esswein, W. (2016): *BPMN4CP Revised – Extending BPMN for Multi-perspective Modeling of Clinical Pathways.* 49th Hawaii International Conference on System Sciences (HICSS), pp. 3249–3258. DOI 10.1109/HICSS.2016.407.
+- Accompanying (extension method/requirement types): Braun, R.; Esswein, W. (2015): *Extending a Business Process Modeling Language for Domain-Specific Adaptation in Healthcare.* Wirtschaftsinformatik, pp. 468–481.
+
+**Problem & motivation.** Clinical pathways (CPs) can be understood as the business processes of a hospital; their modelling promises benefits for system integration, quality management and documentation. BPMN is attractive for this (expressive, clearly defined meta-model, workflow integration), but **generic**: it lacks domain-specific CP concepts (e.g. evidence indicators, resources, clinical restrictions). The authors explicitly address **two stakeholder groups** with opposing knowledge: medical staff as domain experts (little modelling experience) and process analysts as IT experts (little medical knowledge). The framework is designed to be "human-centric" for mixed teams.
+
+**Method.** Design-science research (Hevner); the BPMN extension method by Stroppi et al. (2011) is used and systematically extended. The basis of the domain understanding is, among other things, the five constitutive CP characteristics according to Kinsman et al. (2010). From a domain ontology / a conceptual domain model, the extension need is derived and a valid BPMN extension meta-model is constructed. The revised version went through an iteration based on the practical application in a telemedicine project.
+
+**Content of the extension (revised).** **Resources, documents, goals and quality indicators** are integrated. Resources can be modelled as **resource bundles** (example: "CT" as a bundle of subordinate resources) including relations (e.g. complementary/substitutive). These concepts are deliberately assigned to **perspectives and sub-diagrams** (e.g. process, resource, document perspective) — to **master complexity** and to provide **stakeholder-appropriate diagrams**. The same element can be represented differently per diagram (shape and level of detail vary). Everything is implemented as a reusable **BPMN meta-model extension** (BPMN4CP 2.0).
+
+**Demonstration.** The two versions use different examples: the **original version 2014** demonstrates BPMN4CP on a **wisdom-tooth treatment**, the **revised version 2016** on a (simplified) **stroke pathway** — there, the activity "Stroke Diagnosis" references the resource bundle "CT", and the resource as well as the document perspective are shown in their own diagrams.
+
+**Relevance for this checklist.** BPMN4CP provides the rationale for **SEM-7** (domain-specific artefacts) and **PRA-2** (multi-perspective, stakeholder-specific partial views) and supports the **two-audience logic** (clinical/technical) underlying the entire checklist.
+
+---
+
+## Sources & verification status
+
+**Checked against the full text:**
+
+1. **7PMG** — Mendling, J.; Reijers, H. A.; van der Aalst, W. M. P. (2010): *Seven process modeling guidelines (7PMG)*. Information and Software Technology 52(2), 127–136. *(Full text checked: G1–G7; G4 = "balanced brackets"; G3 rationale incl. engine requirement; > 50 elements ⇒ probability of error > 50 %; real error rate 10–20 %; expert ranking G4>G7>G1>G6>G2>G3>G5 from 21 modellers; G6 experiment with 29 postgraduates; example 37→31 elements.)*
+2. **Kinsman et al. (2010)** — *What is a clinical pathway?* BMC Medicine 8:31. *(Full text/PMC checked: five criteria + operationalisation "1 + ≥ 3".)*
+3. **SEQUAL** — Lindland, O. I.; Sindre, G.; Sølvberg, A. (1994): *Understanding quality in conceptual modeling*. IEEE Software 11(2), 42–49; extended: Krogstie et al. (1995/2006). *(Definitions syntactic/semantic/pragmatic checked; pragmatic separated into social/technical audience.)*
+4. **Soundness** — van der Aalst (soundness criterion); Fahland, D. et al. (2011): *Analysis on demand: Instantaneous soundness checking of industrial business process models*. Data & Knowledge Engineering 70, 448–466. *(Properties and automated checkability checked.)*
+
+**Checked against specification/abstract/excerpts (not the complete running text):**
+
+5. **OMG BPMN 2.0** — Process-modeling conformance subclasses Descriptive/Analytic/Common Executable. *(Verified via ontological analysis and secondary sources.)*
+6. **BPMN4CP** — Braun, R.; Schlieter, H.; Burwitz, M.; Esswein, W. (2014), IEEE BIBM, pp. 9–16; **Revised** (2016), HICSS 49, pp. 3249–3258, DOI 10.1109/HICSS.2016.407. *(Bibliographic key data — authors, venues, pages, DOI, TU Dresden affiliation — verified via IEEE Xplore and the TU Dresden research portal. Methodology, extension content and stakeholder logic checked from abstracts, figure captions and reference lists of several sources. **Correction vs. v0.2:** Revised = HICSS 2016 (not "2015/2016"); demo example 2014 = wisdom tooth, 2016 = stroke. The complete article body is behind the IEEE paywall and could not be read in full text despite several attempts; figure-related details are paraphrased.)*
+7. **STAKOB validation pattern** — Benevento et al. (2023): *Process Modeling and Conformance Checking in Healthcare: A COVID-19 Case Study* (Springer). *(Iterative qualitative validation until consensus checked.)*
+8. **GoM** — Becker, J.; Rosemann, M.; Schütte, R. (1995): *Grundsätze ordnungsmäßiger Modellierung*. Wirtschaftsinformatik 37(5), 435–445. *(Six principles — correctness, clarity, relevance, comparability, economic efficiency, systematic structure — confirmed via the 7PMG full text and secondary sources; the German original text was not consulted directly.)*
+
+**Notes.** "Good BPMN" (correctness, clarity, completeness, consistency) according to B. Silver is a practitioner heuristic (secondary source) and is covered here only secondarily (via GoM/7PMG). One secondary source erroneously cited "30 elements" for G7 — the original source says **50**.
+
+*Status of the contents: source verification, no tool trial. Examples are illustrative and not clinically accepted.*

--- a/docs/governance/abnahme-protokoll-bpmn-patientenpfad.en.md
+++ b/docs/governance/abnahme-protokoll-bpmn-patientenpfad.en.md
@@ -1,0 +1,132 @@
+<!--
+English translation of `abnahme-protokoll-bpmn-patientenpfad.md` (German is the original/authoritative source).
+Provided for reference; keep both language versions in sync and at the same version.
+Status: draft — not final, likely to change. Change history: docs/governance/CHANGELOG.md.
+-->
+
+# Acceptance Protocol — BPMN-modelled patient pathway
+
+*To be filled in during the acceptance meeting. Criteria basis: Instrument v0.3.1 (IDs identical). If a criterion is unclear, see the handout.*
+
+## 0. General data
+
+| Field | Entry |
+|---|---|
+| Pathway / model name | |
+| Model version / commit hash | |
+| Artifact / repository link | |
+| Target conformance class | ☐ Descriptive ☐ Analytic ☐ Common Executable |
+| Date / location of acceptance | |
+| Criteria basis | Acceptance Instrument v0.3.1 |
+| Protocol ID | |
+
+### Participants
+
+| Name | Role | Present |
+|---|---|---|
+| | Clinical lead | ☐ |
+| | Technical lead | ☐ |
+| | Domain expert (clinical) | ☐ |
+| | Facilitation / minutes | ☐ |
+| | | ☐ |
+
+---
+
+## 1. Check results
+
+**Result codes:** ✓ fulfilled · ✗ not fulfilled · – not applicable (justify). **M** = Must, **S** = Should. **Method:** A = tool, R = review, K = consensus.
+
+### A · Technical (understandability & correctness)
+
+| ID | Criterion | M/S | Method | Result | Evidence / remark |
+|---|---|---|---|---|---|
+| SYN-1 | Conformance class declared & adhered to | M | A | ☐✓ ☐✗ ☐– | |
+| SYN-2 | Exactly one start / one end event | M | A/R | ☐✓ ☐✗ ☐– | |
+| SYN-3 | Verb-object labels | S | R | ☐✓ ☐✗ ☐– | |
+| SYN-4 | ≤ 50 symbols / decomposed | S | A | ☐✓ ☐✗ ☐– | |
+| SYN-5 | Paired splits/joins, no OR | S | A/R | ☐✓ ☐✗ ☐– | |
+| STR-1 | Every run reaches the end | M | A | ☐✓ ☐✗ ☐– | |
+| STR-2 | No open parallel branches at the end | M | A | ☐✓ ☐✗ ☐– | |
+| STR-3 | No dead/unreachable activities | M | A | ☐✓ ☐✗ ☐– | |
+| STR-4 | No deadlock/livelock | M | A | ☐✓ ☐✗ ☐– | |
+
+Soundness tool / version: ________________  Run result: ☐ green ☐ findings (see remark)
+
+### B · Clinical (content validity)
+
+| ID | Criterion | M/S | Method | Result | Evidence / remark |
+|---|---|---|---|---|---|
+| SEM-1 | Multidisciplinary (all disciplines as a lane) | M | R | ☐✓ ☐✗ ☐– | |
+| SEM-2 | Guideline / evidence reference noted | S* | R | ☐✓ ☐✗ ☐– | |
+| SEM-3 | Essential steps complete | S* | R | ☐✓ ☐✗ ☐– | |
+| SEM-4 | Transitions tied to deadlines/criteria | S* | R | ☐✓ ☐✗ ☐– | |
+| SEM-5 | Target population/standardization delimited | S* | R | ☐✓ ☐✗ ☐– | |
+| SEM-6 | Face validity: consensus of the domain experts | M | K | ☐✓ ☐✗ ☐– | |
+| SEM-7 | Domain artifacts captured | S | R | ☐✓ ☐✗ ☐– | |
+
+### C · Pragmatic (joint)
+
+| ID | Criterion | M/S | Method | Result | Evidence / remark |
+|---|---|---|---|---|---|
+| PRA-1 | Both sides understand the model the same way | M | R | ☐✓ ☐✗ ☐– | |
+| PRA-2 | Overview and detail view available | S | R | ☐✓ ☐✗ ☐– | |
+| PRA-3 | No superfluous elements | S | R | ☐✓ ☐✗ ☐– | |
+
+---
+
+## 2. Gate evaluation
+
+| Gate | Condition | Result | Justification if "not met" |
+|---|---|---|---|
+| Technical | SYN-1, SYN-2, STR-1…STR-4 all ✓ | ☐ met ☐ not met | |
+| Clinical | SEM-1 ✓ **and** ≥ 3 of 4 from {SEM-2…SEM-5} ✓ **and** SEM-6 ✓ | ☐ met ☐ not met | |
+| Pragmatic | PRA-1 ✓ | ☐ met ☐ not met | |
+
+*Kinsman gate count: fulfilled criteria from {SEM-2, SEM-3, SEM-4, SEM-5} = ____ / 4.*
+
+---
+
+## 3. Conditions & open items (should-deviations / conditions)
+
+| No | Reference (ID) | Item / deficiency | Action | Owner | Due date | Status |
+|---|---|---|---|---|---|---|
+| 1 | | | | | | ☐ open ☐ done |
+| 2 | | | | | | ☐ open ☐ done |
+| 3 | | | | | | ☐ open ☐ done |
+
+---
+
+## 4. Acceptance decision
+
+☐ **Accepted** — all three gates met, no open items.
+☐ **Accepted with conditions** — all three gates met; open should-items per §3 with a due date.
+☐ **Rejected** — at least one gate not met (open must-criterion).
+
+**Decision rationale:**
+
+_____________________________________________________________
+
+**Re-check / re-acceptance date (if conditions or rejection):** ____________
+
+> Decision rule: An open **Must** criterion rules out "Accepted with conditions". "With conditions" is only permissible for open **Should** items.
+
+---
+
+## 5. Signatures
+
+| Role | Name | Date | Signature |
+|---|---|---|---|
+| Clinical lead | | | |
+| Technical lead | | | |
+| Facilitation / minutes | | | |
+
+---
+
+## 6. Attachments / references
+
+- ☐ Model export / diagram (file, version)
+- ☐ Soundness / analysis report (tool, date)
+- ☐ Minutes of the clinical validation session(s) (evidence for SEM-6)
+- ☐ Acceptance Instrument v0.3.1 · ☐ accompanying handout
+
+*This protocol documents a single acceptance. Earlier acceptances of the same pathway are retained as separate protocols (version traceability).*


### PR DESCRIPTION
## Summary

Makes the **Abnahme acceptance instrument bilingual**, sets a **repo language policy**, makes **issue templates bilingual**, and adds **reporting-via-the-issue-tracker** to CONTRIBUTING.

> 🥞 Stacked on #33. Stack: `#29 ← #30 ← #31 ← #32 ← #33 ← this`; auto-retargets to `dev` as parents merge.

## Bilingual approval docs (draft, change-tracked)
- English translations (`*.en.md`) of all three documents alongside the German originals — **German stays authoritative**, EN kept in sync at the same version. Translated by subagents and verified: structure/tables/checkboxes mirror the German 1:1, and **all criteria IDs (SYN×5, STR×4, SEM×7, PRA×3), method/severity codes, citations, DOIs and numbers are preserved verbatim**.
  - `abnahme-checkliste-…en.md` (instrument v0.3.1), `…handout-…en.md` (v0.2), `…protokoll-…en.md` (template v1.0).
- **They are not final** → change tracking via **`docs/governance/CHANGELOG.md`** + each doc's `version`, and a **bilingual version/status table** in the governance README.

## Language policy (documented in AGENTS.md + CONTRIBUTING.md)
- Repo default **German** (README, CONVENTIONS, governance instrument); **technical docs in English** (ADRs, AGENTS, CONTRIBUTING, `docs/model-issues/`); **Abnahme instrument bilingual**; **issue templates always bilingual (DE+EN)**.

## Issue templates + reporting
- `.github/ISSUE_TEMPLATE/bpmn-model-issue.md` is now **bilingual (DE · EN)**.
- CONTRIBUTING gains a **Reporting issues** section: report via the repo's **GitHub issue tracker** using the templates; BPMN-XML problems flow through `docs/model-issues/` (agents report, humans file) — consistent with the model guard (#33).

## Test plan
- [x] All 3 `.en.md` carry the translation notice, all criteria IDs present, line counts mirror the German (177/176, 196/196, 132/133), no unintended residual German (the one hit is the German work-title inside a citation).
- [x] Governance README table + CHANGELOG link both languages.
- [x] No code/gate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
