### PR TITLE
chore(release): cut 0.2.0-rc.1 release candidate (+ enforce 0.x axis per ADR-0002)

### DIFF
--- a/docs/decisions/0002-versioning-and-release.md
+++ b/docs/decisions/0002-versioning-and-release.md
@@ -28,6 +28,17 @@ specifications rather than adopting SemVer 2.0.0 verbatim.)
 **Pre-1.0.0:** treat `0.MINOR` as the breaking axis. **Reach `1.0.0` at the first
 formal acceptance test "Accepted"** (see [`../governance/`](../governance/)).
 
+`release-please-config.json` enforces this with **`bump-minor-pre-major: true`** — a
+breaking change (`feat!`/`refactor!`) bumps the **MINOR** (`0.1.0 → 0.2.0`), not to `1.0.0`,
+while no model has yet passed the acceptance test.
+
+**Release candidates.** To cut a candidate rather than a final release, set
+**`"release-as": "X.Y.Z-rc.N"`** in `release-please-config.json` (e.g. `0.2.0-rc.1`);
+release-please forces that version and marks the `-rc` tag as a GitHub **pre-release** (not
+`latest`), so no consumer treats it as stable. Advance the suffix for further candidates
+(`-rc.2`, …) and **remove `release-as`** to cut the final `X.Y.Z` once the acceptance test
+is "Accepted".
+
 Bumps are derived from **Conventional Commit** messages scoped by pathway file
 (`feat(treatment)!: …` = breaking; `feat(aftercare): …` = minor; `fix`/`docs` = patch).
 Note: commit-lint enforces the *type*, not the *semantic correctness* of the bump — a

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,9 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "package-name": "mihub-lung-cancer-pathway"
+      "package-name": "mihub-lung-cancer-pathway",
+      "bump-minor-pre-major": true,
+      "release-as": "0.2.0-rc.1"
     }
   },
   "include-component-in-tag": false,


### PR DESCRIPTION
Makes the pending release a **release candidate** instead of a final `1.0.0`.

- **`release-as: 0.2.0-rc.1`** — release-please will regenerate the release PR (#41) to propose **`0.2.0-rc.1`**, tagged as a GitHub **pre-release** (not `latest`).
- **`bump-minor-pre-major: true`** — fixes why it proposed `1.0.0`: per **ADR-0002**, the repo stays on the `0.x` axis (a breaking change bumps MINOR) until the **first acceptance test is 'Accepted'** — which hasn't happened (gate red by design). So `0.2.0`, not `1.0.0`.
- ADR-0002 updated to document the RC mechanism (advance `-rc.N` / remove `release-as` for the final cut).

Takes effect on the release PR once this reaches `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)