### PR TITLE
build(gate): human-readable element labels in conformance-gate findings

### DIFF
--- a/tools/check-model-metrics.mjs
+++ b/tools/check-model-metrics.mjs
@@ -31,6 +31,7 @@ import { readFileSync } from 'node:fs';
 import { BpmnModdle } from 'bpmn-moddle';
 import { resolveBpmnFiles } from './bpmn-files.mjs';
 import { extensions } from './moddle/descriptors.mjs';
+import { labelForElement } from './element-names.mjs';
 
 const MAX_ELEMENTS_PER_LEVEL = 50; // Abnahmetest SYN-4 / 7PMG G7
 
@@ -85,21 +86,24 @@ for (const file of files) {
 
   for (const lvl of levels) {
     const els = lvl.flowElements;
-    const inclusive = byType(els, 'bpmn:InclusiveGateway').length;
-    const complex = byType(els, 'bpmn:ComplexGateway').length;
-    const starts = byType(els, 'bpmn:StartEvent').length;
-    const ends = byType(els, 'bpmn:EndEvent').length;
+    const orGateways = [...byType(els, 'bpmn:InclusiveGateway'), ...byType(els, 'bpmn:ComplexGateway')];
+    const startEvents = byType(els, 'bpmn:StartEvent');
+    const endEvents = byType(els, 'bpmn:EndEvent');
     const count = els.length;
 
-    if (inclusive || complex) {
-      fileOr += inclusive + complex;
-      fileLines.push(
-        `    ✖ SYN-5 [${lvl.name}] OR-gateway(s): ${inclusive} inclusive, ${complex} complex — not allowed`
-      );
+    if (orGateways.length) {
+      fileOr += orGateways.length;
+      // Name each offending gateway by its editor label so it can be located, not just counted.
+      fileLines.push(`    ✖ SYN-5 [${lvl.name}] ${orGateways.length} OR-gateway(s) — not allowed:`);
+      for (const g of orGateways) fileLines.push(`        ${labelForElement(g)}`);
     }
-    if (starts !== 1 || ends !== 1) {
+    if (startEvents.length !== 1 || endEvents.length !== 1) {
       fileWarn++;
-      fileLines.push(`    ⚠ SYN-2 [${lvl.name}] start-events=${starts}, end-events=${ends} (expected 1/1 — review)`);
+      fileLines.push(
+        `    ⚠ SYN-2 [${lvl.name}] start-events=${startEvents.length}, end-events=${endEvents.length} (expected 1/1 — review)`
+      );
+      if (startEvents.length > 1) fileLines.push(`        starts: ${startEvents.map(labelForElement).join(', ')}`);
+      if (endEvents.length > 1) fileLines.push(`        ends:   ${endEvents.map(labelForElement).join(', ')}`);
     }
     if (count > MAX_ELEMENTS_PER_LEVEL) {
       fileWarn++;

--- a/tools/check-soundness.mjs
+++ b/tools/check-soundness.mjs
@@ -32,6 +32,7 @@
  */
 import { readFileSync } from 'node:fs';
 import { resolveBpmnFiles } from './bpmn-files.mjs';
+import { indexFromXml, labelForId } from './element-names.mjs';
 
 // Default host port 8090 (matches the documented `docker run -p 8090:8080` and avoids
 // colliding with services commonly on 8080). Override with SOUNDNESS_URL.
@@ -46,7 +47,11 @@ if (!files.length) {
 }
 
 async function check(file) {
-  const body = JSON.stringify({ bpmn_file_content: readFileSync(file, 'utf8'), properties_to_be_checked: PROPS });
+  const xml = readFileSync(file, 'utf8');
+  // id → editor label, so the analyzer's element ids are locatable by a reviewer.
+  let index = new Map();
+  try { index = await indexFromXml(xml); } catch { /* malformed model → analyzer reports it below */ }
+  const body = JSON.stringify({ bpmn_file_content: xml, properties_to_be_checked: PROPS });
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), Number(process.env.SOUNDNESS_TIMEOUT_MS || 120000));
   try {
@@ -59,7 +64,16 @@ async function check(file) {
       return { kind: 'INCONCLUSIVE', detail: [...new Set(j.unsupported_elements)].join(', ') };
     }
     const viol = (j.property_results || []).filter((r) => !r.fulfilled);
-    if (viol.length) return { kind: 'VIOLATION', detail: viol.map((v) => `${v.property}${v.problematic_elements?.length ? ` [${v.problematic_elements.slice(0, 4).join(', ')}]` : ''}`).join('; ') };
+    if (viol.length)
+      return {
+        kind: 'VIOLATION',
+        detail: viol
+          .map((v) => {
+            const els = (v.problematic_elements || []).slice(0, 4).map((id) => labelForId(id, index));
+            return `${v.property}${els.length ? ` [${els.join(', ')}]` : ''}`;
+          })
+          .join('; '),
+      };
     return { kind: 'SOUND', detail: 'all properties fulfilled' };
   } catch (e) {
     if (e.name === 'AbortError') return { kind: 'ERROR', detail: 'timeout (state-space blowup — the webserver runs without POR)' };

--- a/tools/element-names.mjs
+++ b/tools/element-names.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Resolve BPMN element ids to the human-readable label shown in a model editor.
+ *
+ * The gate's findings come back keyed by element id (bpmnlint `report.id`, the
+ * soundness analyzer's `problematic_elements`, the metrics OR-gateway scan). An id
+ * like `Gateway_18pkxio` is not locatable by a human in the Camunda/bpmn.io editor —
+ * the editor shows the element's `name`. These helpers turn an id (or a parsed moddle
+ * element) into `"Name" (id)`, or `‹unnamed Type› (id)` when the element carries no
+ * name, so a reviewer can find the addressed element.
+ */
+import { BpmnModdle } from 'bpmn-moddle';
+import { extensions } from './moddle/descriptors.mjs';
+
+/** Strip the namespace prefix from a moddle `$type` (e.g. `bpmn:InclusiveGateway` → `InclusiveGateway`). */
+const shortType = (type) => String(type || 'element').replace(/^[A-Za-z0-9_]+:/, '');
+
+/** Collapse multi-line / padded editor labels to a single tidy line (capped, so output stays readable). */
+const cleanName = (name) => {
+  const n = String(name).replace(/\s+/g, ' ').trim();
+  return n.length > 80 ? `${n.slice(0, 79)}…` : n;
+};
+
+/** Format a parsed moddle element directly (it carries `.name`, `.id`, `.$type`). */
+export function labelForElement(el) {
+  if (!el || el.id == null) return '(unknown element)';
+  return el.name ? `"${cleanName(el.name)}" (${el.id})` : `‹unnamed ${shortType(el.$type)}› (${el.id})`;
+}
+
+/**
+ * Walk a parsed definitions tree and index every element that has an id →
+ * Map(id → { name, type }). Generic (covers Process/SubProcess flow elements,
+ * lanes, participants, events, gateways, …) and cycle-safe.
+ */
+export function indexById(root) {
+  const index = new Map();
+  const seen = new Set();
+  const walk = (node) => {
+    if (!node || typeof node !== 'object' || seen.has(node)) return;
+    seen.add(node);
+    if (typeof node.id === 'string' && !index.has(node.id)) {
+      index.set(node.id, { name: node.name, type: node.$type });
+    }
+    for (const key of Object.keys(node)) {
+      if (key === '$parent' || key === '$type' || key === '$attrs') continue;
+      const v = node[key];
+      if (Array.isArray(v)) {
+        for (const item of v) walk(item);
+      } else if (v && typeof v === 'object' && typeof v.$type === 'string') {
+        walk(v);
+      }
+    }
+  };
+  walk(root);
+  return index;
+}
+
+/** Format an id via an index built with {@link indexById}; falls back to the bare id if unknown. */
+export function labelForId(id, index) {
+  const e = index && index.get(id);
+  if (!e) return id; // unknown id (e.g. a non-element token) — show as-is
+  return e.name ? `"${cleanName(e.name)}" (${id})` : `‹unnamed ${shortType(e.type)}› (${id})`;
+}
+
+/** Convenience: parse XML and return an id→{name,type} index. Throws on a parse error. */
+export async function indexFromXml(xml) {
+  const { rootElement } = await new BpmnModdle(extensions).fromXML(xml);
+  return indexById(rootElement);
+}

--- a/tools/lint-bpmn.mjs
+++ b/tools/lint-bpmn.mjs
@@ -31,6 +31,7 @@ import { createRequire } from 'node:module';
 import { BpmnModdle } from 'bpmn-moddle';
 import { resolveBpmnFiles } from './bpmn-files.mjs';
 import { extensions } from './moddle/descriptors.mjs';
+import { indexById, labelForId } from './element-names.mjs';
 
 const require = createRequire(import.meta.url);
 const { Linter } = require('bpmnlint');
@@ -68,6 +69,7 @@ for (const file of files) {
 
   const reports = await linter.lint(rootElement);
   const rules = Object.keys(reports);
+  const index = indexById(rootElement); // id → human-readable editor label
 
   let fileErrors = 0;
   let fileWarnings = 0;
@@ -77,7 +79,9 @@ for (const file of files) {
       const isError = r.category === 'error';
       if (isError) fileErrors++;
       else fileWarnings++;
-      lines.push(`    ${isError ? 'error  ' : 'warning'}  ${(r.id || '').padEnd(18)} ${r.message}  (${rule})`);
+      // Report the editor label (`"Name" (id)`) so the element is locatable, not the bare id.
+      const where = r.id ? `  →  ${labelForId(r.id, index)}` : '';
+      lines.push(`    ${isError ? 'error  ' : 'warning'}  ${r.message}${where}  (${rule})`);
     }
   }
 


### PR DESCRIPTION
The conformance gate reported elements by **bare id** (e.g. `Gateway_18pkxio`), which a reviewer can't locate in the BPMN editor. Findings now show the **editor label** — `"Name" (id)`, or `‹unnamed Type› (id)` when the element has no name.

- **new `tools/element-names.mjs`** — resolves id → label via a generic, cycle-safe walk of the parsed moddle tree.
- **bpmnlint** — `Element is not connected  →  "Vorstellung beim Hausarzt" (Activity_1150s5c)`
- **metrics** — SYN-5 now **names each OR-gateway** (was a bare count); SYN-2 lists extra start/end events by label.
- **soundness** — the analyzer's `problematic_elements` map to labels.

Multi-line clinical labels collapse to one line (capped 80). **No change to pass/fail behaviour** — naming/roundtrip green, bpmnlint/metrics red by design (now locatable). The four OR-gateways are themselves unnamed in the models → `‹unnamed InclusiveGateway› (id)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)