### PR TITLE
docs(model-issues): cite flagged elements by editor label, not bare id

### DIFF
--- a/docs/model-issues/2026-06-25-baseline.md
+++ b/docs/model-issues/2026-06-25-baseline.md
@@ -7,13 +7,19 @@ reproducible: `npm run check:conformance`, `npm run check:metrics`, and `npm run
 (with the analyzer container, see `docs/decisions/0003`).
 
 > Suggested labels for all: `model`. Per-issue extras noted below.
+>
+> Elements are cited as **`"Label" (id)`** where the model carries a name — the same form the
+> gate now prints (`npm run check:conformance`), so a reviewer can locate them in the editor.
+> A few flagged elements (the OR-gateways, the stub processes) are **themselves unnamed** in the
+> models and can only be found by id.
 
 ---
 
 ### Issue 1 — Replace the 4 OR-gateways with XOR/AND (SYN-5)
 
 - **Affected:** `models/lung-cancer-treatment-pathway.bpmn` (`Gateway_18pkxio`, `Gateway_19kiq8e`),
-  `models/lung-cancer-aftercare-pathway.bpmn` (`Gateway_04r56n3`, `Gateway_1tvjymy`).
+  `models/lung-cancer-aftercare-pathway.bpmn` (`Gateway_04r56n3`, `Gateway_1tvjymy`) — all four are
+  **unnamed** `bpmn:InclusiveGateway`s, so locate them by id in the editor.
 - **Found:** `bpmn:InclusiveGateway` present — `metrics` SYN-5 (blocking), bpmnlint
   `no-inclusive-gateway`=error, and the soundness analyzer lists them as *unsupported*.
 - **Acceptance-test criteria:** SYN-5 (no OR-gateway); CONVENTIONS R5.
@@ -24,8 +30,9 @@ reproducible: `npm run check:conformance`, `npm run check:metrics`, and `npm run
 ### Issue 2 — Fix structural correctness defects (disconnected nodes, implicit/missing start-end, labels) + dead activities
 
 - **Affected:** all sub-pathways (99 bpmnlint errors). Dead activities (soundness `NoDeadActivities`):
-  `diagnostic` (`Activity_063n77a, 0dmkmqr, 0u7tiem, 11j60zy`), `molecular-tumor-board`
-  (`Activity_11na49y, 1kyvkmk, 1phtl9y, 1s1obtx`), `tumor-board` (`Activity_07zzmzl, 09vqotg, 0k6eg9w, 0yme8s3`).
+  - `diagnostic`: "Anamnese" (`Activity_063n77a`), "Überweisung" (`Activity_0dmkmqr`), "Vorbereitung" (`Activity_0u7tiem`), "Mediastinales Staging (z.B. EBUS/EUS, Mediastinoskopie)" (`Activity_11j60zy`)
+  - `molecular-tumor-board`: "Vorbereitung des Patienten/ Falls" (`Activity_11na49y`), "Befundübermittlung" (`Activity_1kyvkmk`), "(Wieder-) Vorstellung im MTB" (`Activity_1phtl9y`), "Humangenetische Aufklärung" (`Activity_1s1obtx`)
+  - `tumor-board`: "Fachabteilungen einladen" (`Activity_07zzmzl`), "PACS Bilder einlesen" (`Activity_09vqotg`), "Beschlussfassung und Protokollierung" (`Activity_0k6eg9w`), "Durchführung" (`Activity_0yme8s3`)
 - **Found:** bpmnlint `no-disconnected`, `no-implicit-start`/`no-implicit-end`,
   `start-event-required`/`end-event-required`, `label-required`, `single-blank-start-event`
   (overarching); soundness `NoDeadActivities` violated on the analyzable files (disconnected ⇒ dead).
@@ -56,7 +63,7 @@ reproducible: `npm run check:conformance`, `npm run check:metrics`, and `npm run
 ### Issue 5 — Resolve empty / stub processes
 
 - **Affected:** `diagnostic` (`Process_0bdppus`, `Process_1cffczp`), `patient-consultation`
-  (`Process_168oe6g`, `Process_0emc66x`) — extra `<process>` elements beyond the main one.
+  (`Process_168oe6g`, `Process_0emc66x`) — extra, **unnamed** `<process>` elements beyond the main one.
 - **Found:** bpmnlint `start-event-required` / `end-event-required` reported against these
   process ids (they contain no start/end), i.e. empty black-box participant processes.
 - **Acceptance-test criteria:** SYN-2; PRA-3 (relevance).
@@ -66,10 +73,12 @@ reproducible: `npm run check:conformance`, `npm run check:metrics`, and `npm run
 
 ### Issue 6 — Decide modelling of intermediate catch events + decompose the overarching pathway (SYN-2/SYN-4, soundness analyzability)
 
-- **Affected:** `overarching` (`Event_06iq4pa, 1884p82, 0t8i28j`), `aftercare`
-  (`Event_1f3bojn, 08adr55`), `patient-consultation` (`Event_0wmvigt`) carry
-  `intermediateCatchEvent`s the soundness analyzer does not support; `overarching` also has
-  **5 start events** (SYN-2) and **140 flow elements** (> 50, SYN-4).
+- **Affected:** these `intermediateCatchEvent`s the soundness analyzer does not support:
+  - `overarching`: "Wartezeit auf einen Termin < 2 Wochen, Notfallsprechstunde täglich möglich [LC SoS 2.1.3]" (`Event_06iq4pa`), "Zeit bis zur Mitteilung der Diagnose: < 1 Woche [LC SoS 2.1.5]" (`Event_1884p82`, `Event_0t8i28j`)
+  - `aftercare`: "Warten bis Nachsorgetermin" (`Event_1f3bojn`), "6 Monate seit letztem Nachsorgetermin vergangen" (`Event_08adr55`)
+  - `patient-consultation`: "Termin für das Patientengespräch" (`Event_0wmvigt`)
+
+  `overarching` also has **5 start events** (SYN-2) and **140 flow elements** (> 50, SYN-4).
 - **Found:** soundness *INCONCLUSIVE* (unsupported `intermediateCatchEvent`); `metrics` SYN-2/SYN-4.
 - **Acceptance-test criteria:** SYN-2, SYN-4; affects STR analyzability.
 - **Suggested remodeling:** a modelling decision — decompose the overarching pathway via Call


### PR DESCRIPTION
Companion to the gate-labels change (#43): the `docs/model-issues` backlog now cites each flagged element as **`"Label" (id)`** (resolved via `tools/element-names.mjs`) instead of a bare id, so issues are locatable in the editor. The four OR-gateways and the stub processes are genuinely **unnamed** in the models → flagged id-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)