### PR TITLE
fix(release): unpin release-as — stop the duplicate-tag release-please failure

### DIFF
--- a/docs/decisions/0002-versioning-and-release.md
+++ b/docs/decisions/0002-versioning-and-release.md
@@ -37,10 +37,13 @@ while no model has yet passed the acceptance test.
 `release-please-config.json`: `release-as` forces the version and `prerelease: true` marks the
 GitHub release as a **pre-release** (not `latest`), so no consumer treats it as stable.
 (`release-as` **alone does not** flag the pre-release — both keys are required; a missed
-`prerelease: true` is why `v0.2.0-rc.1` first published as a full release.) Advance the suffix for
-further candidates (`-rc.2`, …); to cut the final `X.Y.Z` once the acceptance test is "Accepted",
-**remove both `release-as` and `prerelease`** (otherwise the stable release is wrongly marked a
-pre-release).
+`prerelease: true` is why `v0.2.0-rc.1` first published as a full release.) **After a candidate is
+tagged, remove (or advance) `release-as`** — if it stays pinned to an already-released version,
+release-please re-proposes it and the release step **fails with a duplicate-tag (`already_exists`)
+error** (this happened after `v0.2.0-rc.1` was cut). With `prerelease: true` kept, release-please
+proposes the next candidate (`-rc.2`, …) itself once there is a releasable commit. To cut the final
+`X.Y.Z` once the acceptance test is "Accepted", **remove both `release-as` and `prerelease`**
+(otherwise the stable release is wrongly marked a pre-release).
 
 Bumps are derived from **Conventional Commit** messages scoped by pathway file
 (`feat(treatment)!: …` = breaking; `feat(aftercare): …` = minor; `fix`/`docs` = patch).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
       "release-type": "simple",
       "package-name": "mihub-lung-cancer-pathway",
       "bump-minor-pre-major": true,
-      "release-as": "0.2.0-rc.1",
       "prerelease": true
     }
   },


### PR DESCRIPTION
Promotes the release-please fix (#54) to `main` (where release-please reads its config). Removes the pinned `release-as: 0.2.0-rc.1` that caused the **duplicate-tag (`already_exists`) failure** when the redundant release PR #53 was merged. The push that lands this is itself safe: release-please then evaluates the **unpinned** config and won't re-propose the already-cut `v0.2.0-rc.1`.

Docs-only + config; no models. `v0.2.0-rc.1` (prerelease) is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)