### PR TITLE
Promote dev → main: Zenodo concept-DOI citation wiring

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,6 +16,7 @@ authors:
   - name: "Forschungsgruppe Digital Health, Technische Universität Dresden"
     website: "https://tu-dresden.de/bu/wirtschaft/winf/digital-health"
 license: CC-BY-4.0
+doi: "10.5281/zenodo.20943916"  # concept DOI (all versions); resolves to the latest Zenodo release
 repository-code: "https://github.com/forschungsgruppe-digital-health/mihub-lung-cancer-pathway"
 url: "https://github.com/forschungsgruppe-digital-health/mihub-lung-cancer-pathway"
 version: 0.1.0

--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ Die EU Joint Action [CraNE](https://crane4health.eu/) (_Creation of National Com
 
 ---
 
+## Zitieren / Citation
+
+Bitte über den **Concept-DOI** (alle Versionen) zitieren:
+**[`10.5281/zenodo.20943916`](https://doi.org/10.5281/zenodo.20943916)** — er verweist stets auf die neueste archivierte Version. Maschinenlesbare Metadaten in [`CITATION.cff`](./CITATION.cff) (GitHub-Schaltfläche „Cite this repository“). Für die exakte Reproduzierbarkeit einer bestimmten Release den jeweiligen **Versions-DOI** verwenden (z. B. `10.5281/zenodo.20943917` für `v0.2.1-rc.1`). _Cite via the concept DOI (all versions); it always resolves to the latest archived version._
+
 ## Lizenz
 
 Dieses Repository steht unter der **[Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)** Lizenz.

--- a/docs/governance/abnahme-checkliste-bpmn-patientenpfad.en.md
+++ b/docs/governance/abnahme-checkliste-bpmn-patientenpfad.en.md
@@ -14,7 +14,7 @@ autor: "[Nachname, Initiale]"
 affiliation: "[Einrichtung]"
 orcid: "[ORCID]"
 lizenz: "CC BY 4.0"
-persistent_id: "[DOI/Zenodo nach Hinterlegung]"
+persistent_id: "10.5281/zenodo.20943916 (concept DOI of the repository archive)"
 audience: "clinical and technical stakeholders; including modeling beginners"
 ---
 
@@ -22,7 +22,9 @@ audience: "clinical and technical stakeholders; including modeling beginners"
 
 ## Suggested citation
 
-> [Nachname, Initiale] ([Jahr]). *Abnahmetest-Checkliste für BPMN-modellierte Patientenpfade* (Version 0.3) [Evaluationsinstrument]. [Einrichtung]. [DOI].
+> [Surname, Initial] ([Year]). *Acceptance Test Checklist for BPMN-Modelled Patient Pathways* (Version 0.3) [evaluation instrument]. [Institution]. https://doi.org/10.5281/zenodo.20943916.
+
+*(The DOI points to the repository archive "Lungenkrebspatientenpfad – MiHUB (BPMN-Modell)", in which this instrument is included; a standalone instrument DOI would require a separate Zenodo deposit.)*
 
 When used in a publication, please additionally cite the core sources named in the Construct-to-source mapping (§4).
 

--- a/docs/governance/abnahme-checkliste-bpmn-patientenpfad.md
+++ b/docs/governance/abnahme-checkliste-bpmn-patientenpfad.md
@@ -13,7 +13,7 @@ autor: "[Nachname, Initiale]"
 affiliation: "[Einrichtung]"
 orcid: "[ORCID]"
 lizenz: "CC BY 4.0"
-persistent_id: "[DOI/Zenodo nach Hinterlegung]"
+persistent_id: "10.5281/zenodo.20943916 (Concept-DOI des Repository-Archivs)"
 zielgruppe: "klinische und technische Stakeholder; auch Modellierungsanfänger:innen"
 ---
 
@@ -21,7 +21,9 @@ zielgruppe: "klinische und technische Stakeholder; auch Modellierungsanfänger:i
 
 ## Zitationsvorschlag
 
-> [Nachname, Initiale] ([Jahr]). *Abnahmetest-Checkliste für BPMN-modellierte Patientenpfade* (Version 0.3) [Evaluationsinstrument]. [Einrichtung]. [DOI].
+> [Nachname, Initiale] ([Jahr]). *Abnahmetest-Checkliste für BPMN-modellierte Patientenpfade* (Version 0.3) [Evaluationsinstrument]. [Einrichtung]. https://doi.org/10.5281/zenodo.20943916.
+
+*(Der DOI verweist auf das Repository-Archiv „Lungenkrebspatientenpfad – MiHUB (BPMN-Modell)“, in dem dieses Instrument enthalten ist; ein eigenständiger Instrument-DOI würde eine separate Zenodo-Hinterlegung erfordern.)*
 
 Bei Verwendung in einer Publikation bitte zusätzlich die im Konstrukt-Quellen-Mapping (§4) genannten Kernquellen zitieren.
 


### PR DESCRIPTION
Wires the Zenodo concept DOI into CITATION.cff, the README citation section, and the acceptance-test instrument (DE+EN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)