### PR TITLE
docs(release): release-archive control (.gitattributes) + CITATION authors/ORCIDs + version sync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,38 @@
+# Controls the contents of the GitHub release source archive — and therefore the Zenodo deposit.
+#
+# GitHub builds the release tarball/zip with `git archive`, which honors `export-ignore`, and
+# Zenodo archives that tarball. So the published/archived release is trimmed to the citable
+# artifact — the BPMN models + their SVG images — plus the essential metadata, without the
+# development & tooling scaffolding.
+#
+# KEPT in the archive: models/ (.bpmn + .svg), README.md, LICENSE, CITATION.cff, DISCLAIMER.md
+# Everything listed below is EXCLUDED.
+#
+# NOTE: applies to FUTURE releases only — the file must be present in the tagged commit. The
+# already-archived v0.2.1-rc.1 is unaffected. To exclude/keep more, edit the lists below.
+
+# --- development & build tooling ---
+/tools/                         export-ignore
+/skills/                        export-ignore
+/.github/                       export-ignore
+/package.json                   export-ignore
+/package-lock.json              export-ignore
+/release-please-config.json     export-ignore
+/.release-please-manifest.json  export-ignore
+/version.txt                    export-ignore
+/.bpmnlintrc                    export-ignore
+
+# --- editor / agent / repo meta ---
+/.vscode/                       export-ignore
+/.claude/                       export-ignore
+/.agents/                       export-ignore
+/.gitignore                     export-ignore
+/.gitattributes                 export-ignore
+/AGENTS.md                      export-ignore
+/CLAUDE.md                      export-ignore
+
+# --- contributor & process docs (not part of the model artifact) ---
+/CONTRIBUTING.md                export-ignore
+/CONVENTIONS.md                 export-ignore
+/CODE_OF_CONDUCT.md             export-ignore
+/docs/                          export-ignore

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,17 +9,27 @@ abstract: >-
   interoperability-reference artifact — not clinically validated and not for use
   in direct patient care (see DISCLAIMER.md).
 type: dataset
-# TODO before the first DOI release: replace the institutional author below with the
-# individual authors (given-names / family-names / orcid), keeping the institution as
-# an affiliation. The Zenodo record version comes from the git tag, not this file.
+# Author order is provisional (listed alphabetically) — set the intended authorship before a
+# stable release; add further contributors as needed.
 authors:
-  - name: "Forschungsgruppe Digital Health, Technische Universität Dresden"
-    website: "https://tu-dresden.de/bu/wirtschaft/winf/digital-health"
+  - given-names: Rebecca
+    family-names: Scheel
+    affiliation: "Forschungsgruppe Digital Health, Technische Universität Dresden"
+    orcid: "https://orcid.org/0009-0001-6054-7812"
+  - given-names: Hannes
+    family-names: Schlieter
+    affiliation: "Forschungsgruppe Digital Health, Technische Universität Dresden"
+    orcid: "https://orcid.org/0000-0002-6513-9017"
+  - given-names: Marcel
+    family-names: Susky
+    affiliation: "Forschungsgruppe Digital Health, Technische Universität Dresden"
+    orcid: "https://orcid.org/0000-0002-3906-0452"
 license: CC-BY-4.0
 doi: "10.5281/zenodo.20943916"  # concept DOI (all versions); resolves to the latest Zenodo release
 repository-code: "https://github.com/forschungsgruppe-digital-health/mihub-lung-cancer-pathway"
 url: "https://github.com/forschungsgruppe-digital-health/mihub-lung-cancer-pathway"
-version: 0.1.0
+version: "0.2.1-rc.1"
+date-released: "2026-06-26"
 keywords:
   - BPMN
   - clinical pathway


### PR DESCRIPTION
**Release packaging** (`.gitattributes export-ignore`): the GitHub release source archive — which Zenodo deposits — is trimmed to **models/ (.bpmn + .svg) + README + LICENSE + CITATION.cff + DISCLAIMER**; dev/tooling/docs scaffolding excluded. Verified with `git archive`. Future releases only.

**CITATION.cff**: individual authors w/ verified TU-Dresden ORCIDs (Scheel `0009-0001-6054-7812`, Schlieter `0000-0002-6513-9017`, Susky `0000-0002-3906-0452`); version `0.1.0`→`0.2.1-rc.1` + date-released.

⚠️ Excludes `docs/` (the acceptance-test instrument) from future archives — flagged for decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)