### PR TITLE
Promote dev → main: instrument-in-archive, author order, cut v0.2.1-rc.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,8 +5,8 @@
 # artifact — the BPMN models + their SVG images — plus the essential metadata, without the
 # development & tooling scaffolding.
 #
-# KEPT in the archive: models/ (.bpmn + .svg), README.md, LICENSE, CITATION.cff, DISCLAIMER.md
-# Everything listed below is EXCLUDED.
+# KEPT in the archive: models/ (.bpmn + .svg), README.md, LICENSE, CITATION.cff, DISCLAIMER.md,
+# and docs/governance/ (the acceptance-test instrument). Everything listed below is EXCLUDED.
 #
 # NOTE: applies to FUTURE releases only — the file must be present in the tagged commit. The
 # already-archived v0.2.1-rc.1 is unaffected. To exclude/keep more, edit the lists below.
@@ -35,4 +35,6 @@
 /CONTRIBUTING.md                export-ignore
 /CONVENTIONS.md                 export-ignore
 /CODE_OF_CONDUCT.md             export-ignore
-/docs/                          export-ignore
+# docs/governance/ (the acceptance-test instrument) is KEPT; the process docs are excluded:
+/docs/decisions/                export-ignore
+/docs/model-issues/             export-ignore

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,9 +9,12 @@ abstract: >-
   interoperability-reference artifact — not clinically validated and not for use
   in direct patient care (see DISCLAIMER.md).
 type: dataset
-# Author order is provisional (listed alphabetically) — set the intended authorship before a
-# stable release; add further contributors as needed.
+# Author order: first author Susky, senior (last) author Schlieter; add further contributors as needed.
 authors:
+  - given-names: Marcel
+    family-names: Susky
+    affiliation: "Forschungsgruppe Digital Health, Technische Universität Dresden"
+    orcid: "https://orcid.org/0000-0002-3906-0452"
   - given-names: Rebecca
     family-names: Scheel
     affiliation: "Forschungsgruppe Digital Health, Technische Universität Dresden"
@@ -20,10 +23,6 @@ authors:
     family-names: Schlieter
     affiliation: "Forschungsgruppe Digital Health, Technische Universität Dresden"
     orcid: "https://orcid.org/0000-0002-6513-9017"
-  - given-names: Marcel
-    family-names: Susky
-    affiliation: "Forschungsgruppe Digital Health, Technische Universität Dresden"
-    orcid: "https://orcid.org/0000-0002-3906-0452"
 license: CC-BY-4.0
 doi: "10.5281/zenodo.20943916"  # concept DOI (all versions); resolves to the latest Zenodo release
 repository-code: "https://github.com/forschungsgruppe-digital-health/mihub-lung-cancer-pathway"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -27,8 +27,8 @@ license: CC-BY-4.0
 doi: "10.5281/zenodo.20943916"  # concept DOI (all versions); resolves to the latest Zenodo release
 repository-code: "https://github.com/forschungsgruppe-digital-health/mihub-lung-cancer-pathway"
 url: "https://github.com/forschungsgruppe-digital-health/mihub-lung-cancer-pathway"
-version: "0.2.1-rc.1"
-date-released: "2026-06-26"
+version: "0.2.1-rc.2"
+date-released: "2026-06-27"
 keywords:
   - BPMN
   - clinical pathway


### PR DESCRIPTION
Brings the release-archive instrument inclusion + author order, and the Release-As footer that tells release-please to cut v0.2.1-rc.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)